### PR TITLE
Add guidelines for the sprint presentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,9 @@
         }
     ],
     "workbench.iconTheme": "vscode-icons",
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "markdown.extension.toc.levels": "2..6",
+    "markdown.extension.toc.updateOnSave": true,
+    "markdown.extension.toc.unorderedList.marker": "-",
+    "markdown.extension.theming.decoration.renderTrailingSpace": true
 }

--- a/doc/development/sprint_planning_guidelines.md
+++ b/doc/development/sprint_planning_guidelines.md
@@ -1,0 +1,3 @@
+# Sprint Planning Guidelines
+
+TODO

--- a/doc/development/sprint_review_presentation.md
+++ b/doc/development/sprint_review_presentation.md
@@ -1,0 +1,174 @@
+# Sprint Review Presentation Guideline
+
+Creating a good presentation for a **Sprint Review** in PAF is important for communicating the team's achievements, identifying challenges, and planning for future work. 
+
+To present the sprint progress effectively, especially when dealing with complex software projects, it can be beneficial to split the presentations into two distinct parts:
+
+1. **General Sprint Progress Overview**: This focuses on the big-picture updates, team-wide accomplishments, challenges, and next steps.
+
+2. **Individual Pull Request (PR) Presentations**: These dive into the details of specific features or changes made during the sprint.
+
+- [Sprint Review Presentation Guideline](#sprint-review-presentation-guideline)
+  - [**A. General Sprint Progress Overview Presentation**](#a-general-sprint-progress-overview-presentation)
+    - [1. **Structure of the General Overview**](#1-structure-of-the-general-overview)
+      - [2. **Presentation Style**](#2-presentation-style)
+    - [**B. Individual Pull Request (PR) Presentations**](#b-individual-pull-request-pr-presentations)
+      - [1. **Structure of the PR Presentation**](#1-structure-of-the-pr-presentation)
+      - [2. **Presentation Style**](#2-presentation-style-1)
+    - [**How to Present Both Types**](#how-to-present-both-types)
+    - [1. **Know Your Audience**](#1-know-your-audience)
+    - [2. **Presentation Structure**](#2-presentation-structure)
+    - [3. **Highlight Key Accomplishments**](#3-highlight-key-accomplishments)
+    - [4. **Keep It Visual**](#4-keep-it-visual)
+    - [5. **Engage with a Live Demo**](#5-engage-with-a-live-demo)
+    - [6. **Discuss Challenges and Blockers**](#6-discuss-challenges-and-blockers)
+    - [7. **Use Data to Back Up Progress**](#7-use-data-to-back-up-progress)
+    - [8. **Address Stakeholder Questions**](#8-address-stakeholder-questions)
+    - [9. **Conclude with Next Steps**](#9-conclude-with-next-steps)
+    - [10. **Keep Timing in Check**](#10-keep-timing-in-check)
+    - [Presentation Tips](#presentation-tips)
+
+---
+
+## **A. General Sprint Progress Overview Presentation**
+
+This presentation is designed for a broader audience and focuses on the overall progress made during the sprint. It highlights major milestones, project status, and challenges, without diving into technical implementation details.
+
+### 1. **Structure of the General Overview**
+
+- **Title Slide**: Sprint number, project name, team, and sprint dates.
+- **Agenda**: Outline the structure of the presentation.
+  - Sprint goals
+  - Completed work
+  - In-progress work
+  - Challenges and blockers
+  - Metrics (velocity, burn-down)
+  - Next steps
+- **Sprint Goals**: Briefly describe the objectives of the sprint and how they fit into the overall project roadmap.
+- **Completed Work**: Provide an overview of features that were completed. This section should focus on **overall vehicle improvement** rather than technical details.
+  - Optionally include a **demo** of key features.
+  - **Before-and-after visuals** of new functionality if applicable.
+- **In-progress Work**: Mention features or tasks that were started but not completed, along with explanations of why they weren’t finished.
+- **Challenges & Blockers**: Present the key blockers and how they were addressed or escalated. If some remain unresolved, suggest plans for mitigation.
+- **Sprint Metrics**: Include relevant metrics:
+  - Any improvements in testing or driving score.
+- **Next Steps**: Outline the focus areas for the next sprint, upcoming deadlines, and potential risks.
+
+## 2. **Presentation Style**
+
+
+
+### **B. Individual Pull Request (PR) Presentations**
+
+These are more focused, technical presentations meant to review individual pull requests (PRs) from the sprint. They are aimed at the development team and technical stakeholders, providing detailed insight into the code changes, implementation logic, and technical considerations of each PR.
+
+#### 1. **Structure of the PR Presentation**
+   - **Title Slide**: Pull request title, associated ticket number(s), and contributor(s).
+   - **Agenda**:
+     - Overview of the PR
+     - Key changes made
+     - Technical challenges and solutions
+     - Code review outcomes and testing
+     - Demo (if applicable)
+   - **PR Overview**: Start with the problem or user story the PR addresses.
+     - Describe the goal of the changes (e.g., adding a feature, fixing a bug, refactoring code).
+   - **Key Changes Made**: Go over the technical changes made in the PR.
+     - **Code snippets**: Highlight important parts of the code that were changed or added.
+     - **Design patterns or architectural choices**: Explain any significant technical decisions.
+   - **Technical Challenges and Solutions**: Discuss any technical difficulties encountered while implementing the PR.
+     - Mention how challenges were overcome and what alternatives were considered.
+   - **Code Review Outcomes**: Summarize any feedback from peer reviews.
+     - Highlight any requested changes and how they were addressed.
+     - Point out best practices followed or any areas for future improvement.
+   - **Testing and Validation**: Show how the changes were tested.
+     - **Automated tests**: Unit, integration, or end-to-end tests that were added or updated.
+     - **Manual tests**: If manual validation was done, explain the scenarios tested.
+   - **Demo (if applicable)**: Provide a quick live demo or walkthrough of the feature or bug fix that the PR addresses.
+   - **Next Steps**: If the PR impacts other work or needs further iterations, describe those next steps.
+
+## **Presentation Style**
+
+- **Keep it high-level**: Avoid too much technical jargon.
+- **Use visuals and charts**: Use screenshots, graphs, and videos to illustrate progress.
+- **Interactive**: Ask for feedback, highlight areas that require input or decisions.
+
+## **How to Present Both Types**
+1. **Start with the General Overview**: At the end of each sprint, begin with the sprint progress overview for a high-level summary.
+2. **Move to PR Presentations**: After the general overview, or in a separate meeting, conduct the individual PR presentations. This allows technical team members to dive deeper into the specific contributions.
+3. **Time Management**: Ensure that the general overview presentation is kept brief, while each PR presentation should focus only on the most significant or complex pull requests. Some PRs can be covered in less depth if they are straightforward.
+
+By splitting the presentations this way, you ensure that both technical and non-technical stakeholders get the right level of detail without overwhelming either group. It also creates a space for deeper technical discussions that can lead to better collaboration and code quality.
+
+
+
+
+---
+
+Here are the key guidelines to help you structure an effective sprint progress presentation:
+
+### 1. **Know Your Audience**
+   - **Focus on outcomes**: Highlight the progress made and how it impacts the overall project goals.
+   - **Stay concise**: Respect everyone’s time and keep the presentation focused on what matters most.
+
+### 2. **Presentation Structure**
+   - **Title Slide**: Include the sprint number, project name, team members, and the sprint dates.
+   - **Agenda**: Briefly outline what the presentation will cover (e.g., goals, accomplishments, challenges, next steps).
+   - **Sprint Goals**: Summarize the objectives of the sprint at the beginning of the presentation to set context.
+   - **Completed Work**: Present features, tasks, or user stories completed during the sprint. Provide a demo if applicable.
+   - **In-progress Work**: Highlight tasks that were started but not yet finished, and explain why.
+   - **Challenges & Blockers**: Discuss any impediments or challenges encountered during the sprint and how they were addressed.
+   - **Metrics & KPIs**: Present sprint metrics such as velocity, burn-down charts, or completed vs planned story points.
+   - **Next Steps**: Outline the next steps, including what's planned for the next sprint, upcoming deadlines, or potential risks.
+
+### 3. **Highlight Key Accomplishments**
+   - Focus on the most important outcomes, like **major feature completions** or **noteworthy technical improvements**.
+   - Use **visuals** (like screenshots, code snippets, or demos) to showcase functionality developed during the sprint.
+   - Quantify progress where possible (e.g., "We reduced load times by 30%").
+
+### 4. **Keep It Visual**
+   - Use charts (burn-down, burn-up) and graphs to illustrate progress and work done.
+   - Include **before-and-after visuals** (if applicable) to showcase changes.
+   - Avoid cluttered slides; aim for clarity and simplicity in visuals and text.
+   - Use color coding to highlight completed, in-progress, and blocked tasks (e.g., green for completed, red for blockers).
+
+### 5. **Engage with a Live Demo**
+   - Demonstrating the work completed is the best way to show tangible progress.
+   - Keep the demo short and focused on key user stories or features.
+   - Ensure the demo is **rehearsed** and works smoothly to avoid technical issues during the presentation.
+
+### 6. **Discuss Challenges and Blockers**
+   - Be transparent about any challenges or blockers the team faced.
+   - Discuss **how they were resolved** (if applicable) or what the team needs to resolve them.
+   - Engage stakeholders for their input on how to overcome challenges if they persist.
+
+### 7. **Use Data to Back Up Progress**
+   - Present any metrics like:
+     - **Velocity**: Story points completed versus planned.
+     - **Burn-down/Burn-up charts**: Showing progress towards sprint goals.
+     - **Defects fixed** or any improvements made in code quality, testing coverage, etc.
+   - **Compare** progress with previous sprints to show improvement or trends over time.
+
+### 8. **Address Stakeholder Questions**
+   - Be prepared to answer questions about any aspect of the sprint (e.g., why certain tasks weren't completed).
+   - Use the Q&A as an opportunity to clarify and gather feedback from stakeholders.
+   - Take note of any concerns or feedback for the next sprint planning.
+
+### 9. **Conclude with Next Steps**
+   - Clearly outline what the team is focusing on next (next sprint goals).
+   - Include any **new risks or dependencies** that need to be tracked.
+   - Mention any **key decisions** or **feedback** that need to be incorporated into the next sprint.
+
+### 10. **Keep Timing in Check**
+   - Stick to the allocated time for the review (typically around 30-60 minutes).
+   - Timebox each section (e.g., 5 minutes on goals, 10 minutes on completed work, 10 minutes for a demo, etc.).
+
+---
+
+### Presentation Tips
+   - **Practice** beforehand to ensure smooth delivery.
+   - **Collaborate** with the team to ensure all aspects of the sprint are covered.
+   - Avoid deep technical details unless they are important to the audience.
+   - Use a **consistent slide design** (fonts, colors, layout) to maintain professionalism.
+   - Ensure every team member who worked on critical pieces has a chance to present if possible.
+
+By following these guidelines, you can effectively communicate the progress made during the sprint, demonstrate the team’s work, and engage stakeholders to keep the project moving forward.

--- a/doc/development/sprint_review_presentation.md
+++ b/doc/development/sprint_review_presentation.md
@@ -1,5 +1,11 @@
 # Sprint Review Presentation
 
+**Summary:** Guidelines for creating effective presentations for Sprint Reviews in the PAF project.
+
+- [1. General Sprint Progress Overview Presentation](#1-general-sprint-progress-overview-presentation)
+- [2. Individual Pull Request (PR) Presentations](#2-individual-pull-request-pr-presentations)
+- [3. Presentation Style](#3-presentation-style)
+
 Creating a good presentation for a **Sprint Review** in PAF is important for communicating the team's achievements, identifying challenges, and planning for future work.
 
 To present the sprint progress effectively, especially when dealing with complex software projects, it can be beneficial to split the presentations into two distinct parts:
@@ -7,17 +13,10 @@ To present the sprint progress effectively, especially when dealing with complex
 1. **General Sprint Progress Overview**: This focuses on the big-picture updates, team-wide accomplishments, challenges, and next steps.
 2. **Individual Pull Request (PR) Presentations**: These dive into the details of specific features or changes made during the sprint.
 
->[!INFO] Table of Contents
-
-- [1. General Sprint Progress Overview Presentation](#1-general-sprint-progress-overview-presentation)
-- [2. Individual Pull Request (PR) Presentations](#2-individual-pull-request-pr-presentations)
-- [3. Presentation Style](#3-presentation-style)
-
----
-
 ## 1. General Sprint Progress Overview Presentation
 
 This presentation is designed for a broader audience and focuses on the overall progress made during the sprint. It highlights major milestones, project status, and challenges, without diving into technical implementation details.
+There should be one general overview presentation per sprint, typically delivered a new student who has not presented the general overview before.
 
 **Structure of the General Overview**:
 
@@ -34,7 +33,7 @@ This presentation is designed for a broader audience and focuses on the overall 
   - Any improvements in testing or driving score.
 - **Next Steps**: Outline the focus areas for the next sprint, upcoming deadlines, and potential risks.
 
-**Duration**: 10-20 minutes, depending on the complexity of the sprint.
+**Duration**: 5-20 minutes, depending on the complexity of the sprint.
 
 ## 2. Individual Pull Request (PR) Presentations
 

--- a/doc/development/sprint_review_presentation.md
+++ b/doc/development/sprint_review_presentation.md
@@ -77,4 +77,4 @@ Not every PR has to be presented, but **every student should be able to highligh
 
 ---
 
-next: [Sprint Planning Guidelines](spring_planning_guidelines.md)
+next: [Sprint Planning Guidelines](sprint_planning_guidelines.md)

--- a/doc/development/sprint_review_presentation.md
+++ b/doc/development/sprint_review_presentation.md
@@ -1,49 +1,29 @@
-# Sprint Review Presentation Guideline
+# Sprint Review Presentation
 
-Creating a good presentation for a **Sprint Review** in PAF is important for communicating the team's achievements, identifying challenges, and planning for future work. 
+Creating a good presentation for a **Sprint Review** in PAF is important for communicating the team's achievements, identifying challenges, and planning for future work.
 
 To present the sprint progress effectively, especially when dealing with complex software projects, it can be beneficial to split the presentations into two distinct parts:
 
 1. **General Sprint Progress Overview**: This focuses on the big-picture updates, team-wide accomplishments, challenges, and next steps.
-
 2. **Individual Pull Request (PR) Presentations**: These dive into the details of specific features or changes made during the sprint.
 
-- [Sprint Review Presentation Guideline](#sprint-review-presentation-guideline)
-  - [**A. General Sprint Progress Overview Presentation**](#a-general-sprint-progress-overview-presentation)
-    - [1. **Structure of the General Overview**](#1-structure-of-the-general-overview)
-      - [2. **Presentation Style**](#2-presentation-style)
-    - [**B. Individual Pull Request (PR) Presentations**](#b-individual-pull-request-pr-presentations)
-      - [1. **Structure of the PR Presentation**](#1-structure-of-the-pr-presentation)
-      - [2. **Presentation Style**](#2-presentation-style-1)
-    - [**How to Present Both Types**](#how-to-present-both-types)
-    - [1. **Know Your Audience**](#1-know-your-audience)
-    - [2. **Presentation Structure**](#2-presentation-structure)
-    - [3. **Highlight Key Accomplishments**](#3-highlight-key-accomplishments)
-    - [4. **Keep It Visual**](#4-keep-it-visual)
-    - [5. **Engage with a Live Demo**](#5-engage-with-a-live-demo)
-    - [6. **Discuss Challenges and Blockers**](#6-discuss-challenges-and-blockers)
-    - [7. **Use Data to Back Up Progress**](#7-use-data-to-back-up-progress)
-    - [8. **Address Stakeholder Questions**](#8-address-stakeholder-questions)
-    - [9. **Conclude with Next Steps**](#9-conclude-with-next-steps)
-    - [10. **Keep Timing in Check**](#10-keep-timing-in-check)
-    - [Presentation Tips](#presentation-tips)
+>[!INFO] Table of Contents
+
+- [1. General Sprint Progress Overview Presentation](#1-general-sprint-progress-overview-presentation)
+- [2. Individual Pull Request (PR) Presentations](#2-individual-pull-request-pr-presentations)
+- [3. Presentation Style](#3-presentation-style)
 
 ---
 
-## **A. General Sprint Progress Overview Presentation**
+## 1. General Sprint Progress Overview Presentation
 
 This presentation is designed for a broader audience and focuses on the overall progress made during the sprint. It highlights major milestones, project status, and challenges, without diving into technical implementation details.
 
-### 1. **Structure of the General Overview**
+**Structure of the General Overview**:
 
 - **Title Slide**: Sprint number, project name, team, and sprint dates.
 - **Agenda**: Outline the structure of the presentation.
-  - Sprint goals
-  - Completed work
-  - In-progress work
-  - Challenges and blockers
-  - Metrics (velocity, burn-down)
-  - Next steps
+  - *See below*
 - **Sprint Goals**: Briefly describe the objectives of the sprint and how they fit into the overall project roadmap.
 - **Completed Work**: Provide an overview of features that were completed. This section should focus on **overall vehicle improvement** rather than technical details.
   - Optionally include a **demo** of key features.
@@ -54,121 +34,47 @@ This presentation is designed for a broader audience and focuses on the overall 
   - Any improvements in testing or driving score.
 - **Next Steps**: Outline the focus areas for the next sprint, upcoming deadlines, and potential risks.
 
-## 2. **Presentation Style**
+**Duration**: 10-20 minutes, depending on the complexity of the sprint.
 
-
-
-### **B. Individual Pull Request (PR) Presentations**
+## 2. Individual Pull Request (PR) Presentations
 
 These are more focused, technical presentations meant to review individual pull requests (PRs) from the sprint. They are aimed at the development team and technical stakeholders, providing detailed insight into the code changes, implementation logic, and technical considerations of each PR.
+Not every PR has to be presented, but **every student should be able to highlight their contributions**.
 
-#### 1. **Structure of the PR Presentation**
-   - **Title Slide**: Pull request title, associated ticket number(s), and contributor(s).
-   - **Agenda**:
-     - Overview of the PR
-     - Key changes made
-     - Technical challenges and solutions
-     - Code review outcomes and testing
-     - Demo (if applicable)
-   - **PR Overview**: Start with the problem or user story the PR addresses.
-     - Describe the goal of the changes (e.g., adding a feature, fixing a bug, refactoring code).
-   - **Key Changes Made**: Go over the technical changes made in the PR.
-     - **Code snippets**: Highlight important parts of the code that were changed or added.
-     - **Design patterns or architectural choices**: Explain any significant technical decisions.
-   - **Technical Challenges and Solutions**: Discuss any technical difficulties encountered while implementing the PR.
-     - Mention how challenges were overcome and what alternatives were considered.
-   - **Code Review Outcomes**: Summarize any feedback from peer reviews.
-     - Highlight any requested changes and how they were addressed.
-     - Point out best practices followed or any areas for future improvement.
-   - **Testing and Validation**: Show how the changes were tested.
-     - **Automated tests**: Unit, integration, or end-to-end tests that were added or updated.
-     - **Manual tests**: If manual validation was done, explain the scenarios tested.
-   - **Demo (if applicable)**: Provide a quick live demo or walkthrough of the feature or bug fix that the PR addresses.
-   - **Next Steps**: If the PR impacts other work or needs further iterations, describe those next steps.
+**Structure of the PR Presentation**:
 
-## **Presentation Style**
+- **Title Slide**: Pull request title, associated issue number(s), and contributor(s).
+- **Agenda**:
+  - *See below*
+- **PR Overview**: Start with the problem or issue the PR addresses.
+  - Describe the goal of the changes (e.g., adding a feature, fixing a bug, refactoring code).
+- **Key Accomplishments**: Go over the technical changes made in the PR.
+  - **Code snippets**: Highlight important parts of the code that were changed or added.
+  - **Design patterns or architectural choices**: Explain any significant technical decisions.
+- **Technical Challenges and Solutions**: Discuss any technical difficulties encountered while implementing the PR.
+  - Mention how challenges were overcome and what alternatives were considered.
+- **Code Review Outcomes**: Summarize any feedback from peer reviews.
+  - Highlight any requested changes and how they were addressed.
+  - Point out best practices followed or any areas for future improvement.
+- **Testing and Validation**: Show how the changes were tested.
+  - **Automated tests**: Unit, integration, or end-to-end tests that were added or updated.
+  - **Manual tests**: If manual validation was done, explain the scenarios tested.
+- **Demo (if applicable)**: Provide a quick live demo or walkthrough of the feature or bug fix that the PR addresses.
+- **Next Steps**: If the PR impacts other work or needs further iterations, describe those next steps.
 
-- **Keep it high-level**: Avoid too much technical jargon.
+**Duration**: 5-10 minutes per Pull-Request.
+
+## 3. Presentation Style
+
+- **Focus on outcomes**: Highlight the progress made and how it impacts the overall project goals.
 - **Use visuals and charts**: Use screenshots, graphs, and videos to illustrate progress.
 - **Interactive**: Ask for feedback, highlight areas that require input or decisions.
-
-## **How to Present Both Types**
-1. **Start with the General Overview**: At the end of each sprint, begin with the sprint progress overview for a high-level summary.
-2. **Move to PR Presentations**: After the general overview, or in a separate meeting, conduct the individual PR presentations. This allows technical team members to dive deeper into the specific contributions.
-3. **Time Management**: Ensure that the general overview presentation is kept brief, while each PR presentation should focus only on the most significant or complex pull requests. Some PRs can be covered in less depth if they are straightforward.
-
-By splitting the presentations this way, you ensure that both technical and non-technical stakeholders get the right level of detail without overwhelming either group. It also creates a space for deeper technical discussions that can lead to better collaboration and code quality.
-
-
-
+- **Keep it high-level**: Avoid too much technical jargon.
+- **Stay concise**: Respect everyone’s time and keep the presentation focused on what matters most.
+- **Collaborate**: Collaborate with the team to ensure all aspects of the sprint are covered.
+- **Consistent Slide Design**: Use a consistent slide design (fonts, colors, layout) to improve readability.
+  - Templates for AuxMe-Presentations: <https://mediastore.rz.uni-augsburg.de/get/EJ74okFZE2/>
 
 ---
 
-Here are the key guidelines to help you structure an effective sprint progress presentation:
-
-### 1. **Know Your Audience**
-   - **Focus on outcomes**: Highlight the progress made and how it impacts the overall project goals.
-   - **Stay concise**: Respect everyone’s time and keep the presentation focused on what matters most.
-
-### 2. **Presentation Structure**
-   - **Title Slide**: Include the sprint number, project name, team members, and the sprint dates.
-   - **Agenda**: Briefly outline what the presentation will cover (e.g., goals, accomplishments, challenges, next steps).
-   - **Sprint Goals**: Summarize the objectives of the sprint at the beginning of the presentation to set context.
-   - **Completed Work**: Present features, tasks, or user stories completed during the sprint. Provide a demo if applicable.
-   - **In-progress Work**: Highlight tasks that were started but not yet finished, and explain why.
-   - **Challenges & Blockers**: Discuss any impediments or challenges encountered during the sprint and how they were addressed.
-   - **Metrics & KPIs**: Present sprint metrics such as velocity, burn-down charts, or completed vs planned story points.
-   - **Next Steps**: Outline the next steps, including what's planned for the next sprint, upcoming deadlines, or potential risks.
-
-### 3. **Highlight Key Accomplishments**
-   - Focus on the most important outcomes, like **major feature completions** or **noteworthy technical improvements**.
-   - Use **visuals** (like screenshots, code snippets, or demos) to showcase functionality developed during the sprint.
-   - Quantify progress where possible (e.g., "We reduced load times by 30%").
-
-### 4. **Keep It Visual**
-   - Use charts (burn-down, burn-up) and graphs to illustrate progress and work done.
-   - Include **before-and-after visuals** (if applicable) to showcase changes.
-   - Avoid cluttered slides; aim for clarity and simplicity in visuals and text.
-   - Use color coding to highlight completed, in-progress, and blocked tasks (e.g., green for completed, red for blockers).
-
-### 5. **Engage with a Live Demo**
-   - Demonstrating the work completed is the best way to show tangible progress.
-   - Keep the demo short and focused on key user stories or features.
-   - Ensure the demo is **rehearsed** and works smoothly to avoid technical issues during the presentation.
-
-### 6. **Discuss Challenges and Blockers**
-   - Be transparent about any challenges or blockers the team faced.
-   - Discuss **how they were resolved** (if applicable) or what the team needs to resolve them.
-   - Engage stakeholders for their input on how to overcome challenges if they persist.
-
-### 7. **Use Data to Back Up Progress**
-   - Present any metrics like:
-     - **Velocity**: Story points completed versus planned.
-     - **Burn-down/Burn-up charts**: Showing progress towards sprint goals.
-     - **Defects fixed** or any improvements made in code quality, testing coverage, etc.
-   - **Compare** progress with previous sprints to show improvement or trends over time.
-
-### 8. **Address Stakeholder Questions**
-   - Be prepared to answer questions about any aspect of the sprint (e.g., why certain tasks weren't completed).
-   - Use the Q&A as an opportunity to clarify and gather feedback from stakeholders.
-   - Take note of any concerns or feedback for the next sprint planning.
-
-### 9. **Conclude with Next Steps**
-   - Clearly outline what the team is focusing on next (next sprint goals).
-   - Include any **new risks or dependencies** that need to be tracked.
-   - Mention any **key decisions** or **feedback** that need to be incorporated into the next sprint.
-
-### 10. **Keep Timing in Check**
-   - Stick to the allocated time for the review (typically around 30-60 minutes).
-   - Timebox each section (e.g., 5 minutes on goals, 10 minutes on completed work, 10 minutes for a demo, etc.).
-
----
-
-### Presentation Tips
-   - **Practice** beforehand to ensure smooth delivery.
-   - **Collaborate** with the team to ensure all aspects of the sprint are covered.
-   - Avoid deep technical details unless they are important to the audience.
-   - Use a **consistent slide design** (fonts, colors, layout) to maintain professionalism.
-   - Ensure every team member who worked on critical pieces has a chance to present if possible.
-
-By following these guidelines, you can effectively communicate the progress made during the sprint, demonstrate the team’s work, and engage stakeholders to keep the project moving forward.
+next: [Sprint Planning Guidelines](spring_planning_guidelines.md)


### PR DESCRIPTION
This pull request includes the following changes:

- Updated sprint review guideline
- Updated markdown settings in .vscode/settings.json

Fixes [Feature]: Add guidelines and an example for the sprint presentation #282

- local linting succeded
- decided to not include an example from paf23, because the guidlines are now much more specific.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Markdown editing capabilities with new settings for table of contents (TOC) levels, automatic TOC updates on save, and unordered list markers.
	- Introduced a new guide for creating effective Sprint Review presentations, detailing structure and style for effective communication.

- **Documentation**
	- Added a placeholder section for "Sprint Planning Guidelines" to the development documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->