### PR TITLE
Feat: Update sprint planning guidelines

### DIFF
--- a/doc/development/sprint_planning_guidelines.md
+++ b/doc/development/sprint_planning_guidelines.md
@@ -1,3 +1,85 @@
 # Sprint Planning Guidelines
 
-TODO
+**Summary**: guidelines for the sprint planning process.
+
+- [1. Before Sprint Planning](#1-before-sprint-planning)
+- [2. Sprint Retrospective](#2-sprint-retrospective)
+- [3. At the Start of Sprint Planning](#3-at-the-start-of-sprint-planning)
+- [4. At the End of Sprint Planning](#4-at-the-end-of-sprint-planning)
+- [5. After Sprint Planning](#5-after-sprint-planning)
+- [6. Daily Stand-up](#6-daily-stand-up)
+
+## 1. Before Sprint Planning
+
+1. **Update Issues**
+   - Visit the [Issues page](https://github.com/una-auxme/paf/issues) and:
+     - Add appropriate labels to each issue.
+     - Close any issues that are no longer relevant.
+     - Expand and refine issue descriptions as necessary.
+2. **Create a New Milestone**
+   - Set up a new milestone for the upcoming sprint: [Milestones](https://github.com/una-auxme/paf/milestones).
+3. **Identify Key Weaknesses**
+   - Focus on identifying the biggest weaknesses of the `agent`.
+   - Ask: *If you could magically solve one issue, which one would it be?*
+
+## 2. Sprint Retrospective
+
+Integrate learnings from the previous sprint’s retrospective. Ask:
+
+- Were there any difficulties with communication, task breakdown, or dependencies?
+- How can these issues be addressed in the upcoming sprint?
+
+## 3. At the Start of Sprint Planning
+
+1. **Check Current Project Status**
+   - Review how many sprints are left and the current progress within the semester.
+   - Keep the project’s deadline in mind when planning tasks.
+2. **Brainstorm Tasks/Issues**
+   - Generate meaningful tasks or issues and track them as issues in the system.
+   - Focus on clarity — do not criticize, only clarify each idea.
+3. **Prioritize Tasks**
+   - Ask: *What tasks would make our system function (or "car") better?*
+   - Prioritize tasks based on importance and impact.
+4. **Identify Dependencies**
+   - Ensure dependencies between tasks are clear.
+5. **Estimate Task Duration**
+   - For each task, provide:
+     - Minimum expected time.
+     - Most likely expected time.
+     - Maximum time, beyond which escalation is necessary.
+6. **Assign Issues to Sprint Milestone**
+   - Decide which issues should be included in this sprint.
+
+## 4. At the End of Sprint Planning
+
+1. **Assign Tasks**
+   - Assign each issue to at least one team member.
+2. Capacity Planing:
+   - Consider each team member's availability and workload when assigning
+3. **Review for Missed Problems**
+   - Have any potential problems been overlooked?
+4. **Ensure Workload Distribution**
+   - Confirm that everyone has an appropriate amount of work.
+5. **Clarify Next Steps**
+   - Does everyone know where to start and what their next steps are?
+6. **Clarify Communication Expectations**
+   - Define the expected communication process throughout the sprint.
+
+## 5. After Sprint Planning
+
+1. **Define Workflow for Each Issue**
+   - When will you work on this issue?
+   - How will you collaborate with others?
+2. **Set Escalation Plan**
+   - Define when and how issues should be escalated if problems arise.
+   - Where and when do you need help?
+3. **Plan the Pull Request**
+4. **Sprint Review Preparation**
+   - Prepare for the **Sprint Review** at the end of the sprint, ensuring:
+     - Tasks are complete and meet the Definition of Done.
+     - Documentation and demos are ready for presentation.
+
+## 6. Daily Stand-up
+
+- Engage in the daily asynchronous stand-up:
+  - Example format: *Today, I am working on issue `#xyz`. I’m facing a challenge with this aspect, but otherwise, things are progressing well.*


### PR DESCRIPTION
Update the sprint planning guidelines to provide a more comprehensive and organized structure. This includes adding sections for before sprint planning, sprint retrospective, at the start of sprint planning, at the end of sprint planning, after sprint planning, and daily stand-up. The guidelines also cover tasks such as updating issues, creating a new milestone, identifying key weaknesses, checking current project status, brainstorming tasks/issues, prioritizing tasks, identifying dependencies, estimating task duration, assigning issues to sprint milestone, assigning tasks, capacity planning, reviewing for missed problems, ensuring workload distribution, clarifying next steps, clarifying communication expectations, defining workflow for each issue, setting escalation plan, planning the pull request, and sprint review preparation. The guidelines also provide an example format for the daily stand-up.

Fixes [Feature]: Add sprint planning guidelines #340

