### PR TITLE
Reworked structure & added test build to PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/ISSUE.yml
@@ -1,6 +1,5 @@
 name: "Issue Template"
 description: "Template for creating issues"
-title: ""
 labels: []
 assignees: []
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,9 @@
 name: Build and push image
 
 on:
-  workflow_run:
-    workflows: ["Check code format"]
-    types:
-      - completed
+  pull_request:
+    branches:
+      - "main"
   push:
     branches:
       - main
@@ -43,8 +42,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Test build
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./build/docker/agent/Dockerfile
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            USERNAME=paf
+            USER_UID=1000
+            USER_GID=1000
+
       - name: Build and push Docker image
         id: build
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/.github/workflows/drive.yml
+++ b/.github/workflows/drive.yml
@@ -29,7 +29,6 @@ jobs:
         run: docker compose down -v
       # add rendered JSON as comment to the pull request
       - name: Add simulation results as comment
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/drive.yml
+++ b/.github/workflows/drive.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       AGENT_VERSION: latest
       COMPOSE_FILE: ./build/docker-compose.cicd.yaml
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,10 +1,12 @@
 name: Check code format
 
 on:
-  workflow_run:
-    workflows: ["Linter markdown and code"]
-    types:
-      - completed
+  pull_request:
+    branches:
+      - "main"
+  push:
+    branches:
+      - main
 
 jobs:
     format:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - "main"
+  push:
+    branches:
+      - main
 
 jobs:
     linter:

--- a/doc/development/build_action.md
+++ b/doc/development/build_action.md
@@ -4,16 +4,13 @@
 
 **Summary:** This page explains the GitHub build action we use to create an executable image of our work.
 
-- [GitHub actions](#github-actions)
-  - [General](#general)
-  - [The Dockerfile (`build/docker/build/Dockerfile`)](#the-dockerfile-builddockerbuilddockerfile)
-  - [The `build-and-push-image` job](#the-build-and-push-image-job)
-    - [1. Checkout repository (`actions/checkout@v3`)](#1-checkout-repository-actionscheckoutv3)
-    - [2. Set up Docker Buildx (`docker/setup-buildx-action@v2`)](#2-set-up-docker-buildx-dockersetup-buildx-actionv2)
-    - [3. Log in to the Container registry (`docker/login-action@v2`)](#3-log-in-to-the-container-registry-dockerlogin-actionv2)
-    - [4. Bump version and push tag (`mathieudutour/github-tag-action`)](#4-bump-version-and-push-tag-mathieudutourgithub-tag-action)
-    - [5. Get commit hash](#5-get-commit-hash)
-    - [6. Build and push Docker image](#6-build-and-push-docker-image)
+- [General](#general)
+- [The `build-and-push-image` job](#the-build-and-push-image-job)
+  - [1. Checkout repository (`actions/checkout@v3`)](#1-checkout-repository-actionscheckoutv3)
+  - [2. Set up Docker Buildx (`docker/setup-buildx-action@v2`)](#2-set-up-docker-buildx-dockersetup-buildx-actionv2)
+  - [3. Log in to the Container registry (`docker/login-action@v2`)](#3-log-in-to-the-container-registry-dockerlogin-actionv2)
+  - [4. Test building the image (`docker/build-push-action@v3`)](#4-test-building-the-image-dockerbuild-push-actionv3)
+  - [5. Build and push the image (`docker/build-push-action@v3`)](#5-build-and-push-the-image-dockerbuild-push-actionv3)
 
 ## General
 
@@ -26,12 +23,6 @@ or `docker pull ghcr.io/una-auxme/paf:<version>` to get a specific version.
 
 If action is triggered by a pull request the created image is then used to execute a test run in the leaderboard, using
 the devtest routes. The results of this simulation are then added as a comment to the pull request.
-
-## The Dockerfile ([`build/docker/build/Dockerfile`](../../build/docker/build/Dockerfile))
-
-The Dockerfile uses [Dockerfile+](https://github.com/edrevo/dockerfile-plus) to include
-the [agent Dockerfile](../../build/docker/agent/Dockerfile) to avoid duplicate code.
-The code folder is then copied into the container instead of mounting it as in our dev setup.
 
 ## The `build-and-push-image` job
 
@@ -52,20 +43,13 @@ Logs in with `GITHUB_TOKEN` into the registry (ghcr.io).
 
 Example taken from [here](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images)
 
-### 4. Bump version and push tag ([`mathieudutour/github-tag-action`](https://github.com/mathieudutour/github-tag-action))
+### 4. Test building the image ([`docker/build-push-action@v3`](https://github.com/docker/build-push-action/))
 
-If the current commit is on the `main` branch, this action bumps the version and pushes a new tag to the repo.
+Tries to build the image without pushing it to the repository packages if the workflow was triggered with a pull request.
 
-Major releases can be done manually (e.g. `git tag v1.0.0`).
+### 5. Build and push the image ([`docker/build-push-action@v3`](https://github.com/docker/build-push-action/))
 
-### 5. Get commit hash
-
-If Step 4 was skipped, this step gets the commit hash of the current commit, to be used as a tag for the Docker image.
-
-### 6. Build and push Docker image
-
-Build and push the image to the registry. To avoid large downloads of the base image
+This action builds the image and pushes it to repository under the `latest` tag if the workflow was triggered with a merge to the `main` branch.
+To avoid large downloads of the base image
 the [GitHub Actions cache](https://docs.docker.com/build/building/cache/backends/gha/)
 is used to cache the image after build.
-If the action is run on a branch other than `main`, the image is tagged with the commit hash from Step 5.
-Otherwise, the image is tagged with both the tag created in Step 4 and `latest`.

--- a/doc/development/linter_action.md
+++ b/doc/development/linter_action.md
@@ -4,29 +4,24 @@
 
 **Summary:** This page explains the GitHub lint action we use to unsure Code quality.
 
-- [GitHub actions](#github-actions)
-  - [General](#general)
-  - [Pull requests](#pull-requests)
-  - [🚨 Common Problems](#-common-problems)
-    - [1. Error in the markdown linter](#1-error-in-the-markdown-linter)
-    - [2. Error in the python linter](#2-error-in-the-python-linter)
+- [General](#general)
+- [Pull requests](#pull-requests)
+- [🚨 Common Problems](#-common-problems)
+  - [1. Error in the markdown linter](#1-error-in-the-markdown-linter)
+  - [2. Error in the python linter](#2-error-in-the-python-linter)
 
 ## General
 
 We use a GitHub action to verify code quality.
 These actions are defined in `.github/workflows/linter.yml` and `.github/workflows/format.yml`.
 
-The actions are executed only on pull requests in order not to exceed the [minutes per month included in the Github](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions) free plan.
-This is done by limiting the execution of the action by the following line:
-
-```yaml
-on: pull_request
-```
+The actions are executed on pull requests and on merges to the main branch.
+This should not lead to issues regarding the [GitHub billing plan](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions). If any issues are encountered the linter action can also be run on the self-host runner.
 
 The actions use the same linters described in the section [Linting](./linting.md).
 
 Event though the linters are already active during development,
-the execution on pull request ensures that nobody skips the linter during commit.
+the execution ensures that nobody skips the linter during commit.
 
 ## Pull requests
 


### PR DESCRIPTION
# Description

This PR changes the GitHub actions to always run on merges and on PRs.
They will build a test image on PRs and build the actual image on the `latest` tag.

Fixes #343 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Does this PR introduce a breaking change?

No.

## Most important changes

The GitHub Actions now all trigger on PR and on merge.
The test image and main image now have different labels: `test` (not pushed) and `latest`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a separate build process for pull requests to enhance testing before merging.
	- Added conditional checks to comment simulation results on pull requests.

- **Bug Fixes**
	- Improved workflow triggers for code formatting and linting to run on both pull requests and direct pushes to the main branch.

- **Documentation**
	- Updated workflow configurations for clarity and improved functionality.
	- Enhanced documentation regarding the build process and linter actions for better user understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->