### PR TITLE
Added execution info for drive action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,13 +88,11 @@ jobs:
 
       - name: Save pull request artifact
         if: github.event_name == 'pull_request'
-        env:
-          PR_ID: ${{ github.event.number }}
         run: |
           mkdir -p ./artifact
           printf '{
             "is_pr": true,
-            "pr_id": $PR_ID
+            "pr_id": ${{ github.event.number }}
           }' >> ./artifact/artifact.json
 
       - name: Save merge artifact

--- a/doc/development/drive_action.md
+++ b/doc/development/drive_action.md
@@ -2,18 +2,19 @@
 
 **Summary:** This page explains the GitHub build action we use to evaluate our agent.
 
-- [GitHub actions](#github-actions)
-  - [The drive job](#the-drive-job)
-    - [1. Checkout repository (`actions/checkout@v3`)](#1-checkout-repository-actionscheckoutv3)
-    - [2. Run agent with docker-compose](#2-run-agent-with-docker-compose)
-    - [3. Copy simulation results file out of container](#3-copy-simulation-results-file-out-of-container)
-    - [4. Stop docker-compose stack](#4-stop-docker-compose-stack)
-    - [5. Comment result in pull request `actions/github-script@v6`](#5-comment-result-in-pull-request-actionsgithub-scriptv6)
-  - [Simulation results](#simulation-results)
+- [The drive job](#the-drive-job)
+  - [1. Checkout repository (`actions/checkout@v3`)](#1-checkout-repository-actionscheckoutv3)
+  - [2. Run agent with docker-compose](#2-run-agent-with-docker-compose)
+  - [3. Copy simulation results file out of container](#3-copy-simulation-results-file-out-of-container)
+  - [4. Stop docker-compose stack](#4-stop-docker-compose-stack)
+  - [5. Comment result in pull request `actions/github-script@v6`](#5-comment-result-in-pull-request-actionsgithub-scriptv6)
+- [Simulation results](#simulation-results)
 
 ## The drive job
 
 The `drive` job is executed conditionally on `pull_request`, after the build successfully ran through.
+
+> Warning: Always start the GitHub runner that handles the `drive` action through direct access to the machine. Do not use remote access like `ssh` or `xrdp`.
 
 ### 1. Checkout repository ([`actions/checkout@v3`](https://github.com/actions/checkout))
 


### PR DESCRIPTION
# Description

This PR adds the info that the drive action does not run if the runner was started with remote access.
I've also added a small fix to the PR number that is passed from the `build` action to the `drive` action.

Fixes #467 

## Type of change

- New feature (non-breaking change which adds functionality)

## Does this PR introduce a breaking change?

No.

## Most important changes

See the documentation for the `drive` action.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Improved formatting and structure of the `drive_action.md` document.
	- Added a warning note regarding the GitHub runner setup.
	- Enhanced table of contents for better navigation.
- **Workflow Enhancements**
	- Updated artifact handling in the GitHub Actions workflow for better accuracy in pull request context.
	- Clarified conditions for cache cleanup steps based on event types while preserving existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->