### PR TITLE
Add sprint summary template and update guidelines for submission

### DIFF
--- a/doc/dev_talks/paf24/README.md
+++ b/doc/dev_talks/paf24/README.md
@@ -11,6 +11,7 @@
 - [Student Roles](./student_roles.md)
 - [Joker Rules](./joker_rules_paf24.md)
 - [Sprint Review Meeting Guidelines](./sprint_review_meeting_guidelines.md)
+  - [Sprint Summary Template](./sprint_summary_template.md)
 
 ## Notes for Sprints
 

--- a/doc/dev_talks/paf24/sprint_review_meeting_guidelines.md
+++ b/doc/dev_talks/paf24/sprint_review_meeting_guidelines.md
@@ -17,7 +17,7 @@
 ### 1.1. Pre-Meeting Agenda
 
 - **Summary Submission**: By **Monday at 11:30 AM** (before the meeting), submit a summary of your work on Digicampus.
-  - TODO A template will be provided.
+  - A template can be found here: [Summary of Work Template](./sprint_summary_template.md).
   - Upload your document to DigiCampus at [this link](https://digicampus.uni-augsburg.de/dispatch.php/course/files?cid=5b0c38206c78cc03880bc2e71997220f).
   - Inform us of your group composition and presentation order for our note-taking.
 - **12:00 - 13:30**: Sample Review

--- a/doc/dev_talks/paf24/sprint_summary_template.md
+++ b/doc/dev_talks/paf24/sprint_summary_template.md
@@ -1,0 +1,35 @@
+# Sprint Summary by *FirstName LastName*
+
+- Sprint Review Date: YYYY-MM-DD
+- My team members:
+- Area of contribution:
+
+## 1. My work
+
+### 1.1. Issues and PRs I worked on and my contribution
+
+- Link
+  - My contribution
+
+### 1.2. PRs I reviewed
+
+- Link
+
+### 1.3. Work I contributed but is not directly linked to a PR or an issue
+
+- For example draw.io board updates.
+
+### 1.4. Effort estimate (optional)
+
+- Estimated hours I worked for the project during the last sprint:
+
+## 2. Things I would like to mention (optional)
+
+- Lessons learned
+- Issues faced
+- Feedback
+- Personal reflections
+
+---
+
+Submit your summary to our DigiCampus course page by Monday at 11:30 AM.


### PR DESCRIPTION
A sprint summary template has been created to streamline the submission process for work summaries. The guidelines have been updated to include a link to the new template, ensuring clarity for team members on how to submit their summaries.

Fixes #451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a link to a "Sprint Summary Template" in the PAF24 README for enhanced resource accessibility.
	- Introduced a structured markdown template for documenting sprint contributions.

- **Documentation**
	- Updated Sprint Review Meeting guidelines for clarity, including time allocations and individual assessment criteria. 
	- Enhanced the "Pre-Meeting Checklist" with specific tasks for participants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->