### PR TITLE
Add autoware mini to the research section

### DIFF
--- a/doc/research/README.md
+++ b/doc/research/README.md
@@ -52,3 +52,4 @@ In addition to the research of the previous years, the following resources can b
 - [Awesome 3D Object Detection for Autonomous Driving](https://github.com/PointsCoder/Awesome-3D-Object-Detection-for-Autonomous-Driving)
 - [Microsoft Autonomous Driving Cookbook](https://github.com/microsoft/AutonomousDrivingCookbook)
 - [End-to-End Autonomous Driving](https://github.com/OpenDriveLab/End-to-end-Autonomous-Driving)
+- [UT-ADL/autoware_mini](https://github.com/UT-ADL/autoware_mini)


### PR DESCRIPTION
The autoware mini project has been added to the research section of the documentation.

Fixes #389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new resource link to the "General Autonomous Driving Resources" section for enhanced research support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->