### PR TITLE
mapping_common debugging mode cmake_setup bugfix

### DIFF
--- a/code/mapping/ext_modules/cmake_setup.py
+++ b/code/mapping/ext_modules/cmake_setup.py
@@ -13,32 +13,39 @@ def main():
     parser.add_argument("--packages_dir", required=True, type=str)
     args = parser.parse_args()
 
-    install_instruction = "install"
-    if is_debug_enabled():
-        install_instruction = "develop"
-
     install_base_dir = args.base_dir
     install_lib_dir = args.packages_dir
     install_headers_dir = os.path.join(install_base_dir, "include")
     install_scripts_dir = os.path.join(install_base_dir, "scripts")
     install_data_dir = os.path.join(install_base_dir, "data")
     workingdir = os.path.dirname(os.path.abspath(__file__))
-    subprocess.run(
-        [
-            sys.executable,
-            "setup.py",
-            install_instruction,
-            "--install-base",
+
+    args = [
+        "install",
+        "--install-base",
+        install_base_dir,
+        "--install-lib",
+        install_lib_dir,
+        "--install-headers",
+        install_headers_dir,
+        "--install-scripts",
+        install_scripts_dir,
+        "--install-data",
+        install_data_dir,
+    ]
+    if is_debug_enabled():
+        args = [
+            "develop",
+            "--prefix",
             install_base_dir,
-            "--install-lib",
+            "--install-dir",
             install_lib_dir,
-            "--install-headers",
-            install_headers_dir,
-            "--install-scripts",
+            "--script-dir",
             install_scripts_dir,
-            "--install-data",
-            install_data_dir,
-        ],
+        ]
+
+    subprocess.run(
+        [sys.executable, "setup.py"] + args,
         cwd=workingdir,
         check=True,
     )


### PR DESCRIPTION
# Description

Fixes the develop setup when .debug_enabled is set for the mapping_common package

Fixes #617 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Does this PR introduce a breaking change?

Nope

## Most important changes

The cmake_setup.py

For reviewers: Check if catkin_make works both with and without .debug_enabled

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Refined the installation command logic for better flexibility
  - Updated setup script installation parameters
  - Enhanced debug mode handling during package installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->