### PR TITLE
Itermediate layer data_init crash fix

### DIFF
--- a/code/mapping/src/mapping_data_integration.py
+++ b/code/mapping/src/mapping_data_integration.py
@@ -266,10 +266,14 @@ class MappingDataIntegrationNode(CompatibleNode):
             return
 
         lidar_cluster_entities = (
-            Map.from_ros_msg(self.lidar_cluster_entities_data).entities or []
+            []
+            if self.lidar_cluster_entities_data is None
+            else Map.from_ros_msg(self.lidar_cluster_entities_data).entities
         )
         radar_cluster_entities = (
-            Map.from_ros_msg(self.radar_cluster_entities_data).entities or []
+            []
+            if self.radar_cluster_entities_data is None
+            else Map.from_ros_msg(self.radar_cluster_entities_data).entities
         )
 
         stamp = rospy.get_rostime()


### PR DESCRIPTION
# Description

Fixes a crash of the mapping_data_init node inside the publish_new_map function.
It happened when self.lidar_cluster_entities_data or self.self.radar_cluster_entities_data is None.

Fixes #626 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Does this PR introduce a breaking change?

Nope

## Most important changes

- mapping_data_init.py

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of potential `None` values when processing LiDAR and radar cluster entity data
	- Enhanced robustness of data integration logic to prevent potential runtime errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->