### PR TITLE
666 feature implement lane index filter

### DIFF
--- a/code/mapping/README.md
+++ b/code/mapping/README.md
@@ -34,7 +34,8 @@ flowchart TD
     NF{New empty dataframe} --> A[node: mapping_data_integration]
     S{Sensors} --> A
     A --> F1(filter: GrowthMergingFilter)
-    F1 -->|topic: /paf/hero/mapping/init_data| 1[node: mapping_visualization]
+    F1 --> F2(filter: LaneIndexFilter)
+    F2 -->|topic: /paf/hero/mapping/init_data| 1[node: mapping_visualization]
 ```
 
 This information is kept up-to-date with the package

--- a/code/mapping/ext_modules/mapping_common/filter.py
+++ b/code/mapping/ext_modules/mapping_common/filter.py
@@ -7,8 +7,8 @@ import shapely
 
 from .map import Map
 from .entity import ShapelyEntity, Entity, FlagFilter
-from .shape import Polygon, Shape2D
-from .transform import Transform2D
+from .shape import Polygon, Shape2D, Rectangle
+from .transform import Transform2D, Vector2
 
 
 class MapFilter:
@@ -27,6 +27,25 @@ class MapFilter:
                 Note that unmodified entities are NOT deepcopied.
         """
         raise NotImplementedError
+
+
+@dataclass
+class LaneIndexFilter(MapFilter):
+
+    def filter(self, map):
+        f = FlagFilter(is_lanemark=True)
+        lanemarkings = map.filtered(f)
+        check_box = Entity(
+            confidence=0,
+            priority=0,
+            shape=Rectangle(20, 0.1),
+            transform=Transform2D.new_rotation_translation(
+                1.5708, Vector2.new(0.0, 0.0)
+            ),
+        )
+        lanemarkings.append(check_box)
+        shapely.intersection_all(lanemarkings)
+        return map
 
 
 @dataclass

--- a/code/mapping/ext_modules/mapping_common/filter.py
+++ b/code/mapping/ext_modules/mapping_common/filter.py
@@ -9,6 +9,7 @@ from .map import Map
 from .entity import ShapelyEntity, Entity, FlagFilter, Lanemarking
 from .shape import Polygon, Shape2D, Rectangle
 from .transform import Transform2D, Vector2
+from rospy import loginfo
 
 
 class MapFilter:
@@ -55,6 +56,7 @@ class LaneIndexFilter(MapFilter):
         intersections = map.get_lane_y_axis_intersections(direction="both")
         y_values = [(uuid, intersections[uuid][1]) for uuid in intersections]
         # separate negative and positive values
+
         positive_y = sorted(
             [(uuid, y) for uuid, y in y_values if y > 0], key=lambda x: x[1]
         )
@@ -66,7 +68,7 @@ class LaneIndexFilter(MapFilter):
             labels[uuid] = i + 1  # starts at 1
         for i, (uuid, _) in enumerate(negative_y):
             labels[uuid] = -(i + 1)  # starts at
-
+        loginfo((f"Länge des Dictionaries: {y_values}"))
         # iterate through all Lanemark Entities and give it new position index
         for lanemarking in lanemarkings:
             lanemarking.position_index = labels.get(lanemarking.uuid, 0)

--- a/code/mapping/ext_modules/mapping_common/filter.py
+++ b/code/mapping/ext_modules/mapping_common/filter.py
@@ -56,13 +56,13 @@ class LaneIndexFilter(MapFilter):
         intersections = map.get_lane_y_axis_intersections(direction="both")
         y_values = [(uuid, intersections[uuid][1]) for uuid in intersections]
         # separate negative and positive values
-
         positive_y = sorted(
             [(uuid, y) for uuid, y in y_values if y > 0], key=lambda x: x[1]
         )
         negative_y = sorted(
             [(uuid, y) for uuid, y in y_values if y < 0], key=lambda x: abs(x[1])
         )
+        # creates a dictionary for the labels with uuid as keys
         labels = {}
         for i, (uuid, _) in enumerate(positive_y):
             labels[uuid] = i + 1  # starts at 1

--- a/code/mapping/ext_modules/mapping_common/filter.py
+++ b/code/mapping/ext_modules/mapping_common/filter.py
@@ -32,6 +32,8 @@ class MapFilter:
 @dataclass
 class LaneIndexFilter(MapFilter):
 
+    max_distance_intersections = 0.8
+
     def filter(self, map):
         f = FlagFilter(is_lanemark=True)
         lanemarkings = map.filtered(f)
@@ -43,8 +45,24 @@ class LaneIndexFilter(MapFilter):
                 1.5708, Vector2.new(0.0, 0.0)
             ),
         )
-        lanemarkings.append(check_box)
-        shapely.intersection_all(lanemarkings)
+        # lanemarkings.append(check_box)
+        intersections = []
+        keep_entities = []
+        for marking in lanemarkings:
+            intersections.append(
+                shapely.intersection(
+                    check_box.to_shapely().poly, marking.to_shapely().poly
+                )
+            )
+        tree = map.build_tree(f=f)
+        for intersection in intersections:
+            if (
+                tree.query_nearest(intersection, all_matches=False)[0][1]
+                < self.max_distance_intersections
+            ):
+                continue
+            else:
+                keep_entities.append()
         return map
 
 

--- a/code/mapping/ext_modules/mapping_common/filter.py
+++ b/code/mapping/ext_modules/mapping_common/filter.py
@@ -31,21 +31,49 @@ class MapFilter:
 
 @dataclass
 class LaneIndexFilter(MapFilter):
+    """Updates the Index of lanemark Entities if duplicates have been removed.
+
+    !!!Must be called after GrowthMergingFilter!!!
+
+    - Calculates the y coordinates of the intersection with y axis of each lanemarking.
+    - Gives position_index according to y position:
+        - 1 = lane next to the car on the left.
+        - 2 = second lanemark on the left.
+        - -1 = lane next to the car on the right.
+        - etc.
+
+    Then returns the updated map with all Entities
+    """
 
     def filter(self, map):
+
         lanemark_f = FlagFilter(is_lanemark=True)
         other_f = FlagFilter(is_lanemark=False)
         lanemarkings = map.filtered(lanemark_f)
         other_entities = map.filtered(other_f)
-        intersections = map.get_lane_y_axis_intersections(direction="both")
 
-        y_coordinates = [(uuid, intersections[uuid][1]) for uuid in intersections]
+        intersections = map.get_lane_y_axis_intersections(direction="both")
+        y_values = [(uuid, intersections[uuid][1]) for uuid in intersections]
+        # separate negative and positive values
+        positive_y = sorted(
+            [(uuid, y) for uuid, y in y_values if y > 0], key=lambda x: x[1]
+        )
+        negative_y = sorted(
+            [(uuid, y) for uuid, y in y_values if y < 0], key=lambda x: abs(x[1])
+        )
         labels = {}
-        for i, (uuid, y) in enumerate(y_coordinates):
-            labels[uuid] = (i + 1) * (abs(y) / y)
+        for i, (uuid, _) in enumerate(positive_y):
+            labels[uuid] = i + 1  # starts at 1
+        for i, (uuid, _) in enumerate(negative_y):
+            labels[uuid] = -(i + 1)  # starts at
+
+        # iterate through all Lanemark Entities and give it new position index
         for lanemarking in lanemarkings:
             lanemarking.position_index = labels.get(lanemarking.uuid, 0)
+
+        # insert all updated Lanemarks and non_lanemarking Entities
         updated_map = Map(map.timestamp, other_entities + lanemarkings)
+
         return updated_map
 
 

--- a/code/mapping/ext_modules/mapping_common/map.py
+++ b/code/mapping/ext_modules/mapping_common/map.py
@@ -171,6 +171,39 @@ class Map:
             return True
         return False
 
+    def get_lane_y_axis_intersections(self, direction: str = "left") -> dict:
+        """calculates the intersections of the lanemarks in lane_pos direction
+
+        Args:
+            lane_pos (str): lanemarks on "left", "right" or "both" will be checked.
+            Other inputs will be ignored
+
+        Returns:
+            dict{uuid, coordinate}: dictionary with uuid of lanemark as keys
+            and coordinates as according entries
+        """
+        if direction == "left":
+            y_axis_line = LineString([[0, 0], [0, 1 * 8]])
+        elif direction == "right":
+            y_axis_line = LineString([[0, 0], [0, -1 * 8]])
+        elif direction == "both":
+            y_axis_line = LineString([[0, -8], [0, 8]])
+        else:
+            return {}
+        intersection = []
+        lanemark_filter = FlagFilter(is_lanemark=True)
+        # build map STRtree from map with filter
+        lanemarks = self.filtered(lanemark_filter)
+        lanemarks[0].shape.to_shapely
+        intersections = {}
+        for lanemark in lanemarks:
+            intersection = lanemark.shape.to_shapely(lanemark.transform).intersection(
+                y_axis_line
+            )
+            if not intersection.is_empty:
+                intersections[lanemark.uuid] = intersection
+        return intersections
+
     def project_plane(self, start_point, size_x, size_y):
         """
         Projects a rectangular plane starting from (0, 0) forward in the x-direction.

--- a/code/mapping/ext_modules/mapping_common/map.py
+++ b/code/mapping/ext_modules/mapping_common/map.py
@@ -194,7 +194,6 @@ class Map:
         lanemark_filter = FlagFilter(is_lanemark=True)
         # build map STRtree from map with filter
         lanemarks = self.filtered(lanemark_filter)
-        lanemarks[0].shape.to_shapely
         intersections = {}
         for lanemark in lanemarks:
             intersection = lanemark.shape.to_shapely(lanemark.transform).intersection(

--- a/code/mapping/ext_modules/mapping_common/map.py
+++ b/code/mapping/ext_modules/mapping_common/map.py
@@ -200,7 +200,10 @@ class Map:
                 y_axis_line
             )
             if not intersection.is_empty:
-                intersections[lanemark.uuid] = intersection
+                intersections[lanemark.uuid] = [
+                    intersection.centroid.x,
+                    intersection.centroid.y,
+                ]
         return intersections
 
     def project_plane(self, start_point, size_x, size_y):

--- a/code/mapping/ext_modules/mapping_common/map.py
+++ b/code/mapping/ext_modules/mapping_common/map.py
@@ -183,9 +183,9 @@ class Map:
             and coordinates as according entries
         """
         if direction == "left":
-            y_axis_line = LineString([[0, 0], [0, 1 * 8]])
+            y_axis_line = LineString([[0, 0], [0, 8]])
         elif direction == "right":
-            y_axis_line = LineString([[0, 0], [0, -1 * 8]])
+            y_axis_line = LineString([[0, 0], [0, -8]])
         elif direction == "both":
             y_axis_line = LineString([[0, -8], [0, 8]])
         else:

--- a/code/mapping/launch/mapping.launch
+++ b/code/mapping/launch/mapping.launch
@@ -23,9 +23,9 @@
   
   <arg name="enable_lane_index_filter" default="True" />
 
-
-  <node pkg="mapping" type="mapping_data_integration.py" name="mapping_data_integration"
-    output="screen">
+  <node pkg="mapping" type="debug_wrapper.py" name="mapping_data_integration" output="screen" args="--debug_node=mapping_data_integration.py --debug_port=53000">
+  <!--<node pkg="mapping" type="mapping_data_integration.py" name="mapping_data_integration"
+    output="screen">-->
     <param name="map_publish_rate" value="$(arg map_publish_rate)" />
     <param name="polygon_simplify_tolerance" value="$(arg polygon_simplify_tolerance)" />
 

--- a/code/mapping/launch/mapping.launch
+++ b/code/mapping/launch/mapping.launch
@@ -20,6 +20,8 @@
   <arg name="merge_growth_distance" default="0.3" />
   <arg name="min_merging_overlap_percent" default="0.5" />
   <arg name="min_merging_overlap_area" default="0.5" />
+  
+  <arg name="enable_lane_index_filter" default="True" />
 
 
   <node pkg="mapping" type="mapping_data_integration.py" name="mapping_data_integration"
@@ -47,6 +49,7 @@
     <param name="merge_growth_distance" value="$(arg merge_growth_distance)" />
     <param name="min_merging_overlap_percent" value="$(arg min_merging_overlap_percent)" />
     <param name="min_merging_overlap_area" value="$(arg min_merging_overlap_area)" />
+    <param name="enable_lane_index_filter" value="$(arg enable_lane_index_filter)" />
   </node>
 
 </launch>

--- a/code/mapping/src/mapping_data_integration.py
+++ b/code/mapping/src/mapping_data_integration.py
@@ -9,7 +9,7 @@ from visualization_msgs.msg import MarkerArray, Marker
 import numpy as np
 from typing import List, Optional
 
-from mapping_common.entity import Entity, Flags, Car, Motion2D
+from mapping_common.entity import Entity, Flags, Car, Motion2D, FlagFilter
 from mapping_common.transform import Transform2D, Vector2
 from mapping_common.shape import Circle, Rectangle
 from mapping_common.map import Map
@@ -358,6 +358,9 @@ class MappingDataIntegrationNode(CompatibleNode):
 
         for filter in self.get_current_map_filters():
             map = filter.filter(map)
+        # for debugging
+        f = FlagFilter(is_lanemark=True)
+        marks = map.filtered(f)
         msg = map.to_ros_msg()
         self.map_publisher.publish(msg)
 

--- a/code/mapping/src/mapping_data_integration.py
+++ b/code/mapping/src/mapping_data_integration.py
@@ -13,7 +13,7 @@ from mapping_common.entity import Entity, Flags, Car, Motion2D
 from mapping_common.transform import Transform2D, Vector2
 from mapping_common.shape import Circle, Rectangle
 from mapping_common.map import Map
-from mapping_common.filter import MapFilter, GrowthMergingFilter
+from mapping_common.filter import MapFilter, GrowthMergingFilter, LaneIndexFilter
 from mapping.msg import Map as MapMsg, ClusteredPointsArray
 
 from sensor_msgs.msg import PointCloud2
@@ -377,6 +377,8 @@ class MappingDataIntegrationNode(CompatibleNode):
                     simplify_tolerance=self.get_param("~polygon_simplify_tolerance"),
                 )
             )
+        if self.get_param("~enable_lane_index_filter"):
+            map_filters.append(LaneIndexFilter())
 
         return map_filters
 

--- a/code/mapping/tests/mapping_common/test_shapely.py
+++ b/code/mapping/tests/mapping_common/test_shapely.py
@@ -76,6 +76,8 @@ def get_test_entities() -> List[entity.Entity]:
         style=entity.Lanemarking.Style.SOLID,
         confidence=1.0,
         priority=1.0,
+        position_index=1,
+        predicted=False,
         shape=shape.Rectangle(4.0, 0.2),
         transform=Transform2D.identity(),
         flags=entity.Flags(is_lanemark=True),

--- a/code/perception/src/lane_position.py
+++ b/code/perception/src/lane_position.py
@@ -236,7 +236,7 @@ class lane_position(CompatibleNode):
         else:
             line_length = abs(x / np.cos(angle)) * 2
             length = max(line_length, self.line_length)
-        return length
+        return length + 1
 
     def calc_position_indices(self, points):
         """gives each lanemarking a unique index, where 1 is the lane next to the car


### PR DESCRIPTION
# Description

Added a filter, that recalculates the position indices after the merging growth filter. Since dame lane entieites might be removed in the merging process. Thus the indices might be outdated. This PR includes a new Filter, that fixes this issue
Fixes # (issue)

## Type of change

Please delete options that are not relevant.


- New feature (non-breaking change which adds functionality)


## Does this PR introduce a breaking change?

e.g. is old functionality not usable anymore

## Most important changes

LaneIndexFilter

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [ ] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)

