### PR TITLE
695 feature bicycle overtake should be longer than usual

### DIFF
--- a/code/planning/src/behavior_agent/behaviors/behavior_speed.py
+++ b/code/planning/src/behavior_agent/behaviors/behavior_speed.py
@@ -68,8 +68,6 @@ ot_app_free = Behavior("ot_app_free", -1)
 
 # Wait
 
-ot_wait = Behavior("ot_wait", convert_to_ms(5.0))
-
 ot_wait_free = Behavior("ot_wait_free", -1)
 
 # Enter

--- a/code/planning/src/behavior_agent/behaviors/behavior_speed.py
+++ b/code/planning/src/behavior_agent/behaviors/behavior_speed.py
@@ -68,7 +68,7 @@ ot_app_free = Behavior("ot_app_free", -1)
 
 # Wait
 
-ot_wait_stopped = Behavior("ot_wait_stopped", 3.0)
+ot_wait = Behavior("ot_wait", convert_to_ms(5.0))
 
 ot_wait_free = Behavior("ot_wait_free", -1)
 

--- a/code/planning/src/behavior_agent/behaviors/behavior_speed.py
+++ b/code/planning/src/behavior_agent/behaviors/behavior_speed.py
@@ -68,7 +68,8 @@ ot_app_free = Behavior("ot_app_free", -1)
 
 # Wait
 
-ot_wait_free = Behavior("ot_wait_free", -1)
+ot_wait_free = Behavior("ot_wait_free", convert_to_ms(3.0))
+ot_wait_bicycle = Behavior("ot_wait_bicycle", -1)
 
 # Enter
 

--- a/code/planning/src/behavior_agent/behaviors/overtake.py
+++ b/code/planning/src/behavior_agent/behaviors/overtake.py
@@ -640,11 +640,12 @@ class Wait(py_trees.behaviour.Behaviour):
             and not isinstance(entity, Car)
         ):
             self.ot_bicycle_pub.publish(True)
+            self.curr_behavior_pub.publish(bs.ot_wait_bicycle.name)
             ot_free = tree.is_lane_free(False, 12.0, -6.0)
         else:
             self.ot_bicycle_pub.publish(False)
+            self.curr_behavior_pub.publish(bs.ot_wait_free.name)
             ot_free = tree.is_lane_free(False, self.clear_distance, 15.0)
-        self.curr_behavior_pub.publish(bs.ot_wait_free.name)
         if ot_free:
             self.ot_counter += 1
             if self.ot_counter > 3:

--- a/code/planning/src/behavior_agent/behaviors/overtake.py
+++ b/code/planning/src/behavior_agent/behaviors/overtake.py
@@ -650,7 +650,7 @@ class Wait(py_trees.behaviour.Behaviour):
             self.ot_counter += 1
             if self.ot_counter > 3:
                 rospy.loginfo("Overtake is free!")
-                self.curr_behavior_pub.publish(bs.ot_enter_init.name)
+                self.curr_behavior_pub.publish(bs.ot_wait_free.name)
                 return py_trees.common.Status.SUCCESS
             else:
                 return py_trees.common.Status.RUNNING

--- a/code/planning/src/behavior_agent/behaviors/overtake.py
+++ b/code/planning/src/behavior_agent/behaviors/overtake.py
@@ -630,18 +630,17 @@ class Wait(py_trees.behaviour.Behaviour):
         else:
             self.ot_bicycle_pub.publish(False)
             ot_free = tree.is_lane_free(False, self.clear_distance, 15.0)
+        self.curr_behavior_pub.publish(bs.ot_wait_free.name)
         if ot_free:
             self.ot_counter += 1
             if self.ot_counter > 3:
                 rospy.loginfo("Overtake is free!")
-                self.curr_behavior_pub.publish(bs.ot_wait_free.name)
+                self.curr_behavior_pub.publish(bs.ot_enter_init.name)
                 return py_trees.common.Status.SUCCESS
             else:
-                self.curr_behavior_pub.publish(bs.ot_wait.name)
                 return py_trees.common.Status.RUNNING
         else:
             rospy.loginfo("Overtake still blocked")
-            self.curr_behavior_pub.publish(bs.ot_wait.name)
             self.ot_counter = 0
             return py_trees.common.Status.RUNNING
 

--- a/code/planning/src/behavior_agent/behaviors/unstuck_routine.py
+++ b/code/planning/src/behavior_agent/behaviors/unstuck_routine.py
@@ -157,9 +157,9 @@ class UnstuckRoutine(py_trees.behaviour.Behaviour):
         wait_behaviors = [
             bs.int_wait.name,
             bs.lc_wait.name,
-            bs.ot_wait_stopped,
-            bs.int_app_init,
-            bs.int_app_to_stop,
+            bs.ot_wait.name,
+            bs.int_app_init.name,
+            bs.int_app_to_stop.name,
         ]
 
         # when no curr_behavior (before unparking lane free) or

--- a/code/planning/src/behavior_agent/behaviors/unstuck_routine.py
+++ b/code/planning/src/behavior_agent/behaviors/unstuck_routine.py
@@ -157,7 +157,7 @@ class UnstuckRoutine(py_trees.behaviour.Behaviour):
         wait_behaviors = [
             bs.int_wait.name,
             bs.lc_wait.name,
-            bs.ot_wait.name,
+            bs.ot_wait_free.name,
             bs.int_app_init.name,
             bs.int_app_to_stop.name,
         ]

--- a/code/planning/src/local_planner/motion_planning.py
+++ b/code/planning/src/local_planner/motion_planning.py
@@ -289,8 +289,6 @@ class MotionPlanning(CompatibleNode):
         Returns:
             None: The method updates the self.trajectory attribute with the new path.
         """
-        # add buffer to overtake distance so fully avoid obstacle
-        rospy.loginfo(f"OVERTAKE TYPE: {self.__ot_bicycle}")
         if self.__ot_bicycle:
             waypoints_num = NUM_WAYPOINTS_BICYCLE
         else:
@@ -511,8 +509,6 @@ class MotionPlanning(CompatibleNode):
             elif self.target_speed == corner_speed:
                 self.target_velocity_selector = "corner_speed"
         # self.target_speed = min(self.target_speed, 8)
-        rospy.loginfo(f"TARGET SPEED: {self.target_speed}")
-        rospy.loginfo(f"TARGET VELOCITY SELECTOR: {self.target_velocity_selector}")
         self.velocity_pub.publish(self.target_speed)
         self.velocity_selector_pub.publish(self.target_velocity_selector)
         # self.logerr(f"Speed: {self.target_speed}")
@@ -651,7 +647,6 @@ class MotionPlanning(CompatibleNode):
 
     def __get_speed_overtake(self, behavior: str) -> float:
         speed = 0.0
-        rospy.loginfo(f"{behavior}")
         if behavior == bs.ot_app_blocked.name:
             speed = self.__calc_speed_to_stop_overtake()
         elif behavior == bs.ot_app_free.name:

--- a/code/planning/src/local_planner/motion_planning.py
+++ b/code/planning/src/local_planner/motion_planning.py
@@ -651,8 +651,6 @@ class MotionPlanning(CompatibleNode):
             speed = self.__calc_speed_to_stop_overtake()
         elif behavior == bs.ot_app_free.name:
             speed = self.__calc_speed_to_stop_overtake()
-        elif behavior == bs.ot_wait.name:
-            speed = bs.ot_wait.speed
         elif behavior == bs.ot_wait_free.name:
             speed = self.__get_speed_cruise()
         elif behavior == bs.ot_enter_init.name:

--- a/code/planning/src/local_planner/motion_planning.py
+++ b/code/planning/src/local_planner/motion_planning.py
@@ -652,6 +652,8 @@ class MotionPlanning(CompatibleNode):
         elif behavior == bs.ot_app_free.name:
             speed = self.__calc_speed_to_stop_overtake()
         elif behavior == bs.ot_wait_free.name:
+            speed = bs.ot_wait_free.speed
+        elif behavior == bs.ot_wait_bicycle.name:
             speed = self.__get_speed_cruise()
         elif behavior == bs.ot_enter_init.name:
             speed = self.__get_speed_cruise()

--- a/code/planning/src/local_planner/utils.py
+++ b/code/planning/src/local_planner/utils.py
@@ -16,7 +16,7 @@ TARGET_DISTANCE_TO_STOP = 5
 TARGET_DISTANCE_TO_STOP_OVERTAKE = 7
 # Number of waypoints to be used for the overtaking maneuver
 NUM_WAYPOINTS = 8
-NUM_WAYPOINTS_BICYCLE = 17
+NUM_WAYPOINTS_BICYCLE = 20
 # Earth radius in meters for location_to_GPS
 EARTH_RADIUS_EQUA = 6378137.0
 

--- a/code/planning/src/local_planner/utils.py
+++ b/code/planning/src/local_planner/utils.py
@@ -15,8 +15,8 @@ It containes parameters and utility functions to reduce code in the ros nodes.
 TARGET_DISTANCE_TO_STOP = 5
 TARGET_DISTANCE_TO_STOP_OVERTAKE = 7
 # Number of waypoints to be used for the overtaking maneuver
-NUM_WAYPOINTS = 8
-NUM_WAYPOINTS_BICYCLE = 20
+NUM_WAYPOINTS = 9
+NUM_WAYPOINTS_BICYCLE = 22
 # Earth radius in meters for location_to_GPS
 EARTH_RADIUS_EQUA = 6378137.0
 

--- a/code/planning/src/local_planner/utils.py
+++ b/code/planning/src/local_planner/utils.py
@@ -15,7 +15,8 @@ It containes parameters and utility functions to reduce code in the ros nodes.
 TARGET_DISTANCE_TO_STOP = 5
 TARGET_DISTANCE_TO_STOP_OVERTAKE = 7
 # Number of waypoints to be used for the overtaking maneuver
-NUM_WAYPOINTS = 9
+NUM_WAYPOINTS = 8
+NUM_WAYPOINTS_BICYCLE = 17
 # Earth radius in meters for location_to_GPS
 EARTH_RADIUS_EQUA = 6378137.0
 


### PR DESCRIPTION
# Description
Overtake now triggers a flag for motion planning to use a longer overtake trajectory when overtaking bicycles.
Also made entering overtake a little more restrictive and some minor improvements.

Fixes # 695

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Does this PR introduce a breaking change?

No

## Most important changes

Overtake, Motion Planning

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced overtaking maneuvers now include dedicated bicycle detection, adjusting trajectory planning based on vehicle type.
	- Introduced a new behavior for waiting during bicycle overtaking.
	- Added a constant for bicycle-specific waypoint calculations.

- **Bug Fixes**
	- Corrected a speed threshold issue to ensure smoother transitions during overtaking.

- **Refactor**
	- Streamlined wait behavior and recovery routines by updating behavior selection logic for more reliable performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->