### PR TITLE
Add final presentation guidelines for PAF24

### DIFF
--- a/doc/dev_talks/paf24/README.md
+++ b/doc/dev_talks/paf24/README.md
@@ -12,6 +12,7 @@
 - [Joker Rules](./joker_rules_paf24.md)
 - [Sprint Review Meeting Guidelines](./sprint_review_meeting_guidelines.md)
   - [Sprint Summary Template](./sprint_summary_template.md)
+- [Final Presentation Guidelines](./final_presentation_paf24_information.md)
 
 ## Notes for Sprints
 

--- a/doc/dev_talks/paf24/final_presentation_paf24_information.md
+++ b/doc/dev_talks/paf24/final_presentation_paf24_information.md
@@ -13,7 +13,7 @@
 ⏳ **Total Duration: 130 minutes**
 
 1. **90 minutes** – Final Presentation
-2. **30 minutes** – Questions & Discussion
+2. **30 minutes** – Questions, Discussion and Parallel Demo of the Vehicle Running
 3. **10 minutes** – Break
 4. **20 minutes** – Evaluation by Supervisors
 5. **10 minutes** – Feedback & Conclusion

--- a/doc/dev_talks/paf24/final_presentation_paf24_information.md
+++ b/doc/dev_talks/paf24/final_presentation_paf24_information.md
@@ -1,0 +1,23 @@
+# Final Presentation Guidelines for **PAF24**
+
+📅 **Date & Time:** March 17, 2025, 2:00 PM
+
+📍 **Location:** 1019W
+
+👥 **Attendance Requirement:** All participants must be present unless excused due to illness (proof required).
+
+🎤 **Presentation:** Not everyone is required to present, but all team members must be available for questions.
+
+## **Schedule**
+
+⏳ **Total Duration: 130 minutes**
+
+1. **90 minutes** – Final Presentation
+2. **30 minutes** – Questions & Discussion
+3. **10 minutes** – Break
+4. **20 minutes** – Evaluation by Supervisors
+5. **10 minutes** – Feedback & Conclusion
+
+## General Information for the Final Presentation
+
+[Final Presentation Guidelines](../../development/final_presentation_guidelines.md)

--- a/doc/development/README.md
+++ b/doc/development/README.md
@@ -1,5 +1,14 @@
 # Development in PAF
 
+- [First steps](#first-steps)
+- [Development guidelines](#development-guidelines)
+- [Guidelines](#guidelines)
+- [Templates](#templates)
+  - [`template_class.py`](#template_classpy)
+  - [`template_class_no_comments.py`](#template_class_no_commentspy)
+  - [`template_wiki_page.md`](#template_wiki_pagemd)
+- [Discord Webhook](#discord-webhook)
+
 ## First steps
 
 If this is your first time working with the project you can follow the first steps in [/doc/development/first_steps.md](/doc/development/first_steps.md).
@@ -19,6 +28,15 @@ If you contribute to this project please read the following guidelines first:
    3. [drive action](./drive_action.md)
 7. [Install python packages](./installing_python_packages.md)
 8. [Discord Webhook Documentation](./discord_webhook.md)
+
+## Guidelines
+
+1. [Project Management](./project_management.md)
+2. [Sprint Planning Guidelines](./sprint_planning_guidelines.md)
+3. [Sprint Review Presentation Guidelines](./sprint_review_presentation.md)
+4. [Review Guidelines](./review_guideline.md)
+5. [Final Presentation Guidelines](./final_presentation_guidelines.md)
+6. [Documentation Requirements](./documentation_requirements.md)
 
 ## Templates
 

--- a/doc/development/final_presentation_guidelines.md
+++ b/doc/development/final_presentation_guidelines.md
@@ -1,0 +1,79 @@
+# **Final Presentation Guidelines**
+
+- [**Technical Aspects**](#technical-aspects)
+- [**Presentation Structure**](#presentation-structure)
+- [**Additional Guidelines**](#additional-guidelines)
+
+## **Technical Aspects**
+
+- **Zoom Recording:**
+  - Are we allowed to record audio and screen?
+  - The recording may be provided to PAF25 as an introduction to the project.
+  - If anyone objects, please inform us in advance.
+
+- **Presentation Equipment:**
+  - Ensure that the technology works beforehand (laptop, projector, sound, internet).
+  - If specific software or hardware is required, consult with the supervisors in advance.
+
+## **Presentation Structure**
+
+Possible topics to cover:
+
+🔹 **1. Introduction & Objectives**
+
+- What was the overarching goal of the project?
+- Why is this topic relevant?
+
+🔹 **2. Initial Situation & Problem Statement**
+
+- What was the state of the art when you started? Strengths and weaknesses of the project.
+- Which existing solutions did you build upon?
+- What challenges did you face at the beginning?
+
+🔹 **3. Improvements & Solutions**
+
+- What works better now?
+- What solutions were implemented?
+- Why were certain approaches chosen?
+
+🔹 **4. Validation of Improvements**
+
+- How was success measured?
+- Are there measurable results, diagrams, or comparative data?
+
+🔹 **5. Open Challenges**
+
+- What still does not work well?
+- Where did unexpected problems occur?
+
+🔹 **6. Future Perspectives & Recommendations**
+
+- What should be improved next?
+- What open questions or to-dos exist for future teams?
+
+🔹 **7. Reflection**
+
+- What would you have done differently in hindsight?
+- Which methods or approaches would you use again?
+
+## **Additional Guidelines**
+
+✅ **Tips for a Good Presentation:**
+
+- Clear and concise slides (avoid overloading with information).
+- Prefer practical examples & demos (if possible).
+- Short, understandable explanations.
+  - Avoid excessive technical depth for unnecessary details.
+- Manage time effectively—do not spend too long on one topic.
+
+📢 **Questions & Discussion:**
+
+- Be prepared for critical questions.
+- If someone cannot answer a question immediately, the team can step in.
+
+🎯 **Evaluation Criteria (Possible Aspects):**
+
+- Clarity of the presentation
+- Explanation/visualization of the technical implementation & solutions
+- Reflection & lessons learned
+- Quality of responses during the Q&A session


### PR DESCRIPTION
Introduce comprehensive final presentation guidelines for PAF24, including schedule, technical aspects, presentation structure, and additional tips. Update relevant documentation to link to these new guidelines.

Fixes #709 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a link to access final presentation guidelines within the general resource information.
  - Released a comprehensive final presentation guide with event details including schedule, location, and attendance requirements.
  - Introduced a new document outlining expectations and structure for project presentations.
  - Enhanced the main documentation layout by introducing an organized table of contents and new sections for project management, sprint planning, and presentation preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->