### PR TITLE
726 overtake lane free motion aware

### DIFF
--- a/code/mapping/config/mapping.cfg
+++ b/code/mapping/config/mapping.cfg
@@ -25,7 +25,7 @@ tab_filters.add("enable_merge_filter", bool_t, 0, "Enable or disable the merging
 tab_filters.add("merge_growth_distance", double_t, 0, "Amount shapes grow before merging in meters.", 0.3, 0.0, 5.0)
 tab_filters.add("min_merging_overlap_percent", double_t, 0, "Min overlap of the grown shapes in percent.", 0.5, 0.0, 1.0)
 tab_filters.add("min_merging_overlap_area", double_t, 0, "Min overlap of the grown shapes in m2.", 0.5, 0.0, 5.0)
-tab_filters.add("polygon_simplify_tolerance", double_t, 0, "The polygon simplify tolerance.", 0.01, 0.1, 1.0)
+tab_filters.add("polygon_simplify_tolerance", double_t, 0, "The polygon simplify tolerance.", 0.1, 0.01, 1.0)
 
 tab_lidar = gen.add_group("Lidar", type="tab")
 tab_lidar.add("lidar_z_min", double_t, 0, "Excludes lidar points below this height.", -1.5, -10, 2.0)

--- a/code/mapping/ext_modules/mapping_common/entity.py
+++ b/code/mapping/ext_modules/mapping_common/entity.py
@@ -485,8 +485,8 @@ class Entity:
             value has to be inverted. Use the "get_delta_velocity_of" function for this
             case.
 
-        - result > 0: other moves away from self
-        - result < 0: other moves nearer to self
+        - result > 0: other moves in the forward direction of self
+        - result < 0: other moves in the backward direction of self
 
         Args:
             other (Entity)

--- a/code/mapping/ext_modules/mapping_common/entity.py
+++ b/code/mapping/ext_modules/mapping_common/entity.py
@@ -480,7 +480,10 @@ class Entity:
         return velocity
 
     def get_delta_forward_velocity_of(self, other: "Entity") -> Optional[float]:
-        """Calculates the delta velocity compared to other in the heading of self
+        """Calculates the delta velocity compared to other in the heading of self.
+            This function is only for objects in front. If the entity is behind this
+            value has to be inverted. Use the "get_delta_velocity_of" function for this
+            case.
 
         - result > 0: other moves away from self
         - result < 0: other moves nearer to self
@@ -500,6 +503,29 @@ class Entity:
         )
         relative_motion = other_motion_in_self_coords - self.motion.linear_motion
         return relative_motion.x()
+
+    def get_delta_velocity_of(self, other: "Entity") -> Optional[float]:
+        """Calculates the delta velocity compared to other in the heading of self
+
+        - result > 0: other moves away from self
+        - result < 0: other moves nearer to self
+
+        Args:
+            other (Entity)
+
+        Returns:
+            Optional[float]: Delta velocity if both entities have one.
+        """
+        forward_velocity = self.get_delta_forward_velocity_of(other)
+        if forward_velocity is None:
+            return None
+
+        into_self_local: Transform2D = self.transform.inverse() * other.transform
+        other_position_in_self_coords: Vector2 = into_self_local.translation()
+
+        if other_position_in_self_coords.x() < 0.0:
+            return -forward_velocity
+        return forward_velocity
 
     def get_width(self) -> float:
         """Returns the local width (y-bounds) of the entity

--- a/code/mapping/ext_modules/mapping_common/map.py
+++ b/code/mapping/ext_modules/mapping_common/map.py
@@ -548,7 +548,7 @@ class MapTree:
         if lane_state.is_error():
             return lane_state, None
 
-        if lane_box is None or not lane_state == LaneFreeState.TO_BE_CHECKED:
+        if lane_box is None or lane_state != LaneFreeState.TO_BE_CHECKED:
             return LaneFreeState.SHAPE_ERR, None
 
         colliding_entities = self.get_overlapping_entities(

--- a/code/mapping/ext_modules/mapping_common/map.py
+++ b/code/mapping/ext_modules/mapping_common/map.py
@@ -573,16 +573,12 @@ class MapTree:
 
         hero = self.map.hero()
         if motion_aware and hero is not None:
-            # Does not work if car is behind us as the motion is not calculated. If the
-            # next car is visible it is too late
-
             for i in range(len(colliding_entities) - 1, -1, -1):
                 entity = colliding_entities[i]
-                delta_motion = hero.get_delta_forward_velocity_of(entity.entity)
+                delta_motion = hero.get_delta_velocity_of(entity.entity)
 
                 if delta_motion is not None and delta_motion > 0.5:
                     del colliding_entities[i]
-
         # if there are colliding entities, the lane is not free
         if not colliding_entities:
             return LaneFreeState.FREE, lane_box

--- a/code/planning/src/behavior_agent/behaviors/overtake.py
+++ b/code/planning/src/behavior_agent/behaviors/overtake.py
@@ -280,7 +280,7 @@ class Approach(py_trees.behaviour.Behaviour):
         global OVERTAKE_FREE
         self.ot_distance = 30
         self.ot_counter = 0
-        self.clear_distance = 45
+        self.clear_distance = 50
         OVERTAKE_FREE = False
 
     def update(self):
@@ -340,7 +340,7 @@ class Approach(py_trees.behaviour.Behaviour):
             ot_free, ot_mask = tree.is_lane_free(
                 right_lane=False,
                 lane_length=self.clear_distance,
-                lane_transform=15.0,
+                lane_transform=10.0,
                 check_method="fallback",
             )
             if isinstance(ot_mask, shapely.Polygon):
@@ -414,7 +414,7 @@ class Wait(py_trees.behaviour.Behaviour):
     def initialise(self):
         rospy.loginfo("Waiting for Overtake")
         # slightly less distance since we have already stopped
-        self.clear_distance = 45
+        self.clear_distance = 50
         self.ot_counter = 0
         self.ot_gone = 0
         return True
@@ -483,7 +483,7 @@ class Wait(py_trees.behaviour.Behaviour):
         ot_free, ot_mask = tree.is_lane_free(
             right_lane=False,
             lane_length=self.clear_distance,
-            lane_transform=15.0,
+            lane_transform=10.0,
             check_method="fallback",
         )
 


### PR DESCRIPTION
# Description

The lane free has a motion aware flag now. This results in ignoring objects which have a velocity and move away from the hero. This is especially useful in an overtake scenario and will be used for the intersection check.

Fixes #726 

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


## Does this PR introduce a breaking change?
No

## Most important changes

The correct entities are filtered out.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated polygon simplification settings for improved visual detail.
- **New Features**
	- Enhanced vehicle behavior with new methods for velocity calculations.
	- Introduced motion-aware lane checks for more accurate navigation feedback.
	- Tuned overtaking parameters to provide better clearance and maneuver precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->