### PR TITLE
721 bug preplanning trajectory crashed sometimes at start

### DIFF
--- a/code/planning/src/global_planner/preplanning_trajectory.py
+++ b/code/planning/src/global_planner/preplanning_trajectory.py
@@ -500,7 +500,7 @@ class OpenDriveConverter:
             target = (x_target, y_target)
             still_calculated = False
             if self.pt is not None:
-                for i in range(len(self.pt[0])):
+                for i in range(min(len(self.pt[0]), len(self.pt[1]))):
                     point = (self.pt[0][i], self.pt[1][i])
                     dist = help_functions.euclid_dist(point, target)
                     if dist < TARGET_DIFF:

--- a/code/planning/src/global_planner/preplanning_trajectory.py
+++ b/code/planning/src/global_planner/preplanning_trajectory.py
@@ -586,7 +586,7 @@ class OpenDriveConverter:
                 widths = self.lane_widths(self.road_id)
                 old_w = self.lane_widths(self.old_id)
                 # if previous lane width was the rightmost one
-                if old_w.index(self.width) + 1 == len(old_w):
+                if self.width in old_w and old_w.index(self.width) + 1 == len(old_w):
                     last_p = (self.pt[0][-1], self.pt[1][-1])
                     min_diff = float("inf")
                     w_min = None


### PR DESCRIPTION
# Description

line 589 of code/planning/src/global_planner/preplanning_trajectory.py
old_w.index(self.width) was accessed,
sometimes, self.width isn't in the old_w list and therefore a ValueError is raised

another err was index out of bound, range of length of one list, iterate over items of other list (index sometimes isn't that high so error!)

Fixes #721 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Does this PR introduce a breaking change?

no

## Most important changes

Two unhandled errors in code/planning/src/global_planner/preplanning_trajectory.py fixed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the reliability of trajectory calculations by ensuring consistent data processing, reducing the risk of errors.
- **Refactor**
  - Improved internal logic to handle data boundaries more safely, which contributes to a more robust performance.

These updates aim to provide a smoother and more dependable planning experience with fewer unexpected issues during trajectory computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->