### PR TITLE
Add documentation deadline and repository maintenance guidelines for PAF24 project

### DIFF
--- a/doc/dev_talks/paf24/README.md
+++ b/doc/dev_talks/paf24/README.md
@@ -13,6 +13,7 @@
 - [Sprint Review Meeting Guidelines](./sprint_review_meeting_guidelines.md)
   - [Sprint Summary Template](./sprint_summary_template.md)
 - [Final Presentation Guidelines](./final_presentation_paf24_information.md)
+- [Documentation Deadline](./documentation_deadline.md)
 
 ## Notes for Sprints
 

--- a/doc/dev_talks/paf24/documentation_deadline.md
+++ b/doc/dev_talks/paf24/documentation_deadline.md
@@ -1,0 +1,5 @@
+# PAF24 Documentation Deadline
+
+📅 **Deadline:** 14:00 March 25, 2025
+
+Further details can be found in the [Documentation Requirements](../../development/documentation_requirements.md).

--- a/doc/development/documentation_requirements.md
+++ b/doc/development/documentation_requirements.md
@@ -26,6 +26,7 @@
   - [2.5. Consistency and Style](#25-consistency-and-style)
   - [2.6. Maintenance](#26-maintenance)
   - [2.7. Deprecation](#27-deprecation)
+- [Github Repository](#github-repository)
 
 ## 1. In Code Documentation
 
@@ -173,3 +174,12 @@ docker compose -f build/docker-compose.linting.yaml up
 
 - **Deprecation Notices**: When documentation, documented features or components become outdated, obsolete, or deprecated, remove them whenever possible.
   - If removal is not feasible, clearly mark them as deprecated in the documentation. Additionally, provide guidance on alternative solutions or replacements to help users transition smoothly.
+
+## Github Repository
+
+At the end of the project, ensure that the GitHub repository is well-maintained and organized. This includes:
+
+- **Issues**: Make sure that all issues are up-to-date and well-documented. This includes clear descriptions, labels, project status, and references to related issues.
+  - Close issues that are resolved or no longer relevant.
+- **Pull Requests**: Ensure that you close all pull requests.
+- **Branches**: Remove any unnecessary branches and ensure that the main branch is up-to-date.

--- a/doc/development/documentation_requirements.md
+++ b/doc/development/documentation_requirements.md
@@ -26,7 +26,7 @@
   - [2.5. Consistency and Style](#25-consistency-and-style)
   - [2.6. Maintenance](#26-maintenance)
   - [2.7. Deprecation](#27-deprecation)
-- [Github Repository](#github-repository)
+- [GitHub Repository](#github-repository)
 
 ## 1. In Code Documentation
 
@@ -175,7 +175,7 @@ docker compose -f build/docker-compose.linting.yaml up
 - **Deprecation Notices**: When documentation, documented features or components become outdated, obsolete, or deprecated, remove them whenever possible.
   - If removal is not feasible, clearly mark them as deprecated in the documentation. Additionally, provide guidance on alternative solutions or replacements to help users transition smoothly.
 
-## Github Repository
+## GitHub Repository
 
 At the end of the project, ensure that the GitHub repository is well-maintained and organized. This includes:
 


### PR DESCRIPTION
Introduce a documentation deadline for the PAF24 project and link it in the README. Include guidelines for maintaining the GitHub repository within the documentation requirements.

Fixes #737

