### PR TITLE
Add end overtake if obstacle

### DIFF
--- a/code/mapping/ext_modules/mapping_common/map.py
+++ b/code/mapping/ext_modules/mapping_common/map.py
@@ -736,8 +736,12 @@ class MapTree:
             mask (shapely.Geometry): A Shapely Geometry object representing
                 the target area.
             reference (ShapelyEntity): Entity for the nearest distance calculation
-            min_coverage_percent (float, optional): Defaults to 0.0.
-            min_coverage_area (float, optional): Defaults to 0.0.
+            min_coverage_percent (float, optional):
+                How much of an entity has to be inside the collision mask in percent.
+                Defaults to 0.0.
+            min_coverage_area (float, optional):
+                How much of an entity has to be inside the collision mask in m2.
+                Defaults to 0.0.
 
         Returns:
             Optional[Tuple[ShapelyEntity, float]]:
@@ -772,8 +776,12 @@ class MapTree:
         Args:
             mask (shapely.Geometry): A Shapely Geometry object representing
                 the target area.
-            min_coverage_percent (float, optional): Defaults to 0.0.
-            min_coverage_area (float, optional): Defaults to 0.0.
+            min_coverage_percent (float, optional):
+                How much of an entity has to be inside the collision mask in percent.
+                Defaults to 0.0.
+            min_coverage_area (float, optional):
+                How much of an entity has to be inside the collision mask in m2.
+                Defaults to 0.0.
 
         Returns:
             List[ShapelyEntity]: A list of entities that have at least

--- a/code/mapping/ext_modules/mapping_common/mask.py
+++ b/code/mapping/ext_modules/mapping_common/mask.py
@@ -333,6 +333,7 @@ def build_lead_vehicle_collision_masks(
     front_mask_size: float,
     max_trajectory_check_length: Optional[float] = None,
     rotate_front_mask: float = 0.0,
+    max_centering_dist: Optional[float] = 0.5,
 ) -> List[shapely.Polygon]:
     """Builds a list of collision masks for determining the lead vehicle
     in front of the hero.
@@ -347,6 +348,10 @@ def build_lead_vehicle_collision_masks(
             Max length of the collision masks. Defaults to None.
         rotate_front_mask (float, optional): rotates the static mask in front.
             Usecase: Adjust with the steering angle.
+        max_centering_dist (Optional[float], optional):
+            Centers the trajectory part of the mask onto the front mask,
+            if they align closely enough
+            If None-> No centering.
 
     Returns:
         List[shapely.Polygon]
@@ -371,7 +376,7 @@ def build_lead_vehicle_collision_masks(
     trajectory_line = build_trajectory_from_start(
         trajectory_local,
         start_point=front_mask_end,
-        max_centering_dist=0.5,
+        max_centering_dist=max_centering_dist,
     )
     if max_trajectory_check_length is not None and trajectory_line is not None:
         (trajectory_line, _) = split_line_at(

--- a/code/planning/src/behavior_agent/behaviors/overtake.py
+++ b/code/planning/src/behavior_agent/behaviors/overtake.py
@@ -85,6 +85,7 @@ def calculate_obstacle(
     front_mask_size: float,
     trajectory_check_length: float,
     overlap_percent: float,
+    overlap_area: float = 0.0,
 ) -> Union[Optional[Tuple[ShapelyEntity, float]], py_trees.common.Status]:
     """Calculates if there is an obstacle in front
 
@@ -96,7 +97,10 @@ def calculate_obstacle(
         front_mask_size (float): Length of the static box collision mask in front
         trajectory_check_length (float): Length of the trajectory collision mask
         overlap_percent (float):
-            How much of an entity has to be inside the collision mask
+            How much of an entity has to be inside the collision mask in percent
+        overlap_area (float):
+            How much of an entity has to be inside the collision mask in m2.
+                Defaults to 0.0.
 
     Returns:
         Union[Optional[Tuple[ShapelyEntity, float]], py_trees.common.Status]:
@@ -124,6 +128,7 @@ def calculate_obstacle(
         trajectory,
         front_mask_size=front_mask_size,
         max_trajectory_check_length=trajectory_check_length,
+        max_centering_dist=None,
     )
     if len(collision_masks) == 0:
         # We currently have no valid path to check for collisions.
@@ -178,7 +183,6 @@ class Ahead(py_trees.behaviour.Behaviour):
         self.counter_overtake = 0
         self.old_obstacle_distance = 200
         unset_space_stop_mark(self.stop_proxy)
-        return True
 
     def update(self):
         """
@@ -635,7 +639,8 @@ class Leave(py_trees.behaviour.Behaviour):
                 self.blackboard,
                 front_mask_size=0.0,
                 trajectory_check_length=20.0,
-                overlap_percent=0.5,
+                overlap_percent=1.0,
+                overlap_area=1.0,
             )
             if isinstance(obstacle, py_trees.common.Status):
                 return obstacle


### PR DESCRIPTION
# Description

Overtake behavior: Now ends a running overtake if an obstacle in front appears.

Fixes #751

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Does this PR introduce a breaking change?

Nope

## Most important changes

overtake behavior

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced safety during overtaking maneuvers by adding extra validations. Now, the system verifies that the adjacent lane is clear and that there are no obstacles ahead before completing an overtaking action, leading to improved operational safety.
	- Increased configurability in collision mask generation by introducing a new parameter for centering distance.
  
- **Documentation**
	- Improved clarity of method descriptions by expanding documentation for parameters in the mapping functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->