### PR TITLE
Hotfix: 755 bug motionplanning empty trajectory when leaving trajectory too far

### DIFF
--- a/code/planning/src/local_planner/motion_planning.py
+++ b/code/planning/src/local_planner/motion_planning.py
@@ -28,7 +28,7 @@ from planning.srv import (
 import mapping_common.hero
 import mapping_common.mask
 import mapping_common.map
-from mapping_common.transform import Vector2, Point2, Transform2D
+from mapping_common.transform import Point2, Transform2D
 
 TRAJECTORY_DISTANCE_THRESHOLD: float = 0.5
 """threshold under which the planner decides it is on a trajectory

--- a/code/planning/src/local_planner/motion_planning.py
+++ b/code/planning/src/local_planner/motion_planning.py
@@ -262,15 +262,6 @@ class MotionPlanning(CompatibleNode):
             rospy.logfatal_throttle(1.0, "MotionPlanning: Empty trajectory")
             return
 
-        (start_x, start_y) = local_trajectory.coords[0]
-        start_vector = Vector2.new(start_x, start_y)
-        if start_vector.length() > 100.0:
-            # We are far away from the trajectory
-            # Try to reinitialize trajectory on next position update
-            self.init_trajectory = True
-            rospy.logfatal_throttle(1.0, "MotionPlanning: Too far away from trajectory")
-            # Do not return here, otherwise the car does not continue driving
-
         # Calculation finished, ready for publishing
         local_path = mapping_common.mask.line_to_ros_path(local_trajectory)
 


### PR DESCRIPTION
# Description

Fixes #755

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Does this PR introduce a breaking change?

Nope

## Most important changes

motion planning

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the trajectory processing flow by removing extraneous distance validations, resulting in a more direct publishing of trajectories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->