### PR TITLE
794 general add architecture diagram link to planning documentation

### DIFF
--- a/doc/general/architecture_current.md
+++ b/doc/general/architecture_current.md
@@ -148,7 +148,7 @@ found [here](https://carla.readthedocs.io/en/0.9.8/ros_msgs/#CarlaEgoVehicleCont
 
 In the following, all subscribed and published topics and their corresponding nodes are listed with the format:
 
-- ```name of topic``` \(origin/destination node\) (typo of message) (link to ROS documentation of the message type)
+- ```name of topic``` \(origin/destination node\) (type of message) (link to ROS documentation of the message type)
 
 ## Perception
 

--- a/doc/planning/ACC.md
+++ b/doc/planning/ACC.md
@@ -68,6 +68,7 @@ The following key functions are performed by the ACC node:
 
 4. **Calculate Velocity Based on Trajectory**:
    - Approximates a maximum safe cornering speed by tracing lines at an angle from the front of the car and measuring the distance at which they intersect with the trajectory.
+  
    ![Cornering speed visualization](../assets/planning/ACC_curve_speed_visualization.PNG)
    - Uses linear interpolation to calculate the desired speed based on the intersection distance.
 

--- a/doc/planning/ACC.md
+++ b/doc/planning/ACC.md
@@ -57,6 +57,7 @@ The following key functions are performed by the ACC node:
    - Checks if the necessary data (map and trajectory) is available.
    - Defines a trajectory mask and a rectangle in front of the car that is used to set the area in which a leading vehicle is searched. The rectangle is able to detect possible collisions that are close to the car while the trajectory mask checks the area at a higher distance from the car.
    - Publishes markers to visualize the masks, the chosen leading vehicle, and trajectory intersections.
+  
    ![Leading vehicle markers visualization](../assets/planning/ACC_trajectory_mask_visualization.PNG)
    - Identifies the leading vehicle based on the trajectory mask and the rectangle.
    - Calculates a reasonable speed depending on the leading vehicle using the function `calculate_velocity_based_on_lead`.

--- a/doc/planning/README.md
+++ b/doc/planning/README.md
@@ -11,7 +11,7 @@
 
 ## Architecture Diagram
 
-To get an overview over the general architecture, check the [architecture diagram](link).
+To get an overview over the general architecture, check the [architecture diagram](../general/architecture_current.md#overview). It contains the planning components as well as all the other nodes and their relations.
 
 ## Overview
 


### PR DESCRIPTION
# Description

A link to the architecture diagram was added. Some line breaks were added to improve the layout.

Fixes # 794


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified the description of message types for better understanding.
	- Introduced new image references to visually support key planning functionalities.
	- Updated the architecture diagram link with added contextual information for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->