### PR TITLE
Update libtiff5 package version in Dockerfile to fix dependency issue

### DIFF
--- a/build/docker/carla/Dockerfile
+++ b/build/docker/carla/Dockerfile
@@ -141,7 +141,8 @@ RUN echo "${CARLA_ROOT}/PythonAPI/carla" >>"${LEADERBOARD_VENV}"/lib/python${PYT
   echo "${LEADERBOARD_ROOT}" >>"${LEADERBOARD_VENV}"/lib/python${PYTHON_VERSION}/site-packages/leaderboard.pth
 
 # "Fix" libtiff.so.5 missing for the carla python API
-RUN wget http://security.ubuntu.com/ubuntu/pool/main/t/tiff/libtiff5_4.3.0-6ubuntu0.10_amd64.deb -O libtiff5.deb && \
+# Note: the .10 package was removed from the archive; use .11 which is available.
+RUN wget http://security.ubuntu.com/ubuntu/pool/main/t/tiff/libtiff5_4.3.0-6ubuntu0.11_amd64.deb -O libtiff5.deb && \
   apt-get install -y ./libtiff5.deb && \
   rm libtiff5.deb
 


### PR DESCRIPTION
Resolve a missing dependency issue for the Carla Python API by updating the libtiff5 package version in the Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented build failures by switching to an available libtiff package version from upstream repositories.

* **Chores**
  * Updated container system dependency to libtiff 4.3.0-6ubuntu0.11 to maintain compatibility and incorporate latest security patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->