### PR TITLE
Add ms-vscode.cmake-tools to recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -17,6 +17,7 @@
         "ranch-hand-robotics.rde-pack",
         "timonwong.shellcheck",
         "editorconfig.editorconfig",
-        "phil294.git-log--graph"
+        "phil294.git-log--graph",
+        "ms-vscode.cmake-tools"
     ]
 }


### PR DESCRIPTION
Include the CMake Tools extension in the list of recommended extensions for improved CMake support.