### PR TITLE
835 - Reworking overtake to work better with construction sign and trafficcones

### DIFF
--- a/code/leaderboard_launcher/scripts/launch_leaderboard.dev.sh
+++ b/code/leaderboard_launcher/scripts/launch_leaderboard.dev.sh
@@ -2,11 +2,11 @@
 set -e
 
 exec /workspace/code/leaderboard_launcher/scripts/launch_leaderboard.sh \
-  --agent="/workspace/code/leaderboard_launcher/leaderboard_launcher/agent_dev.py" \
-  --routes="${INTERNAL_WORKSPACE_DIR}/leaderboard/data/routes_devtest.xml" \
+    --agent="/workspace/code/leaderboard_launcher/leaderboard_launcher/agent_dev.py" \
+   --routes="/workspace/code/routes/routes_construction_sign.xml" \
+ # --routes="${INTERNAL_WORKSPACE_DIR}/leaderboard/data/routes_devtest.xml" \
   --routes-subset=0
 
-# --routes="/workspace/code/routes/routes_highway.xml" \
 
 # routes-subset sets the index of the route to run
 # Unset it to run all routes

--- a/code/mapping/mapping_common/map.py
+++ b/code/mapping/mapping_common/map.py
@@ -509,7 +509,7 @@ class MapTree:
             "lanemarking",
             "fallback",
             # "trajectory" not implemented yet
-        ] = "rectangle",
+        ] = "fallback",
         min_coverage_percent: float = 0.0,
         min_coverage_area: float = 0.0,
         lane_angle: float = 5.0,
@@ -590,6 +590,7 @@ class MapTree:
 
                 forward_velocity = hero.get_delta_forward_velocity_of(entity.entity)
                 if forward_velocity is None:
+                    del colliding_entities[i]
                     continue
 
                 into_self_local: Transform2D = (

--- a/code/planning/planning/behavior_agent/behavior_tree.py
+++ b/code/planning/planning/behavior_agent/behavior_tree.py
@@ -191,6 +191,7 @@ def grow_a_tree(
                                                 node.curr_behavior_pub,
                                                 node.overtake_status_client,
                                                 node.end_overtake_client,
+                                                node.stop_marks_client,
                                             ),
                                         ],
                                     ),

--- a/code/planning/planning/behavior_agent/behaviors/unstuck_routine.py
+++ b/code/planning/planning/behavior_agent/behaviors/unstuck_routine.py
@@ -172,18 +172,18 @@ class UnstuckRoutine(py_trees.behaviour.Behaviour):
 
         # when no curr_behavior (before unparking lane free) or
         # a wait behavior occurs, increase the wait stuck duration
-        wait_behaviors = [bs.lc_wait.name, bs.ot_wait.name, bs.parking.name]
-        wait_long_behaviors = [bs.int_wait.name, bs.int_app_to_stop.name]
+        wait_behaviors = [bs.lc_wait.name, bs.parking.name]
+        wait_long_behaviors = [bs.int_wait.name, bs.int_app_to_stop.name, bs.ot_wait.name]
 
         last_duration: float = TRIGGER_WAIT_STUCK_DURATION
         if self.unstuck_count != 0:
             TRIGGER_WAIT_STUCK_DURATION = 5.0
         elif curr_behavior is None or curr_behavior.data in wait_behaviors:
-            TRIGGER_WAIT_STUCK_DURATION = 30.0
+            TRIGGER_WAIT_STUCK_DURATION = 15.0
         elif curr_behavior.data in wait_long_behaviors:
             TRIGGER_WAIT_STUCK_DURATION = 60.0
         else:
-            TRIGGER_WAIT_STUCK_DURATION = 15.0
+            TRIGGER_WAIT_STUCK_DURATION = 10.0
 
         # Set back timer if the duration just got smaller
         if TRIGGER_WAIT_STUCK_DURATION < last_duration:

--- a/code/routes/routes_construction_sign.xml
+++ b/code/routes/routes_construction_sign.xml
@@ -9,7 +9,7 @@
             wind_intensity="10.0" sun_azimuth_angle="-1.0" sun_altitude_angle="15.0" fog_density="2.0"/>
       </weathers>
       <waypoints>
-
+         <position x="497.5" y="5718.3" z="368"/>
          <position x="498.6" y="5863.3" z="364.7"/>
          <position x="355.1" y="6138.1" z="358"/>
          <position x="285.9" y="6127.4" z="358"/>


### PR DESCRIPTION
# Description
To work better with the construction sign the overtake behavior is getting reworked in a way that there is a blocking object (just like intersection stop lines) that block a lane in width and is dynamic to the entity to be overtaken in lenght. This should prevents the car from crashing into the cones.  
The checkbox of the overtake itself is changed in size to make the construction sign possible and other overtakes safer.

Fixes # 835

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Does this PR introduce a breaking change?

e.g. is old functionality not usable anymore
no

## Most important changes

partial rework of the existing overtake so that it works in the construction sign case 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [ ] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)

